### PR TITLE
Unit tests for assignment verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,5 @@ lint/tmp/
 
 .idea
 .idea/*
+
+eppo/src/test/resources/*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+# Make settings - @see https://tech.davis-hansson.com/p/make/
+SHELL := bash
+.ONESHELL:
+.SHELLFLAGS := -eu -o pipefail -c
+.DELETE_ON_ERROR:
+MAKEFLAGS += --warn-undefined-variables
+MAKEFLAGS += --no-builtin-rules
+
+# Log levels
+DEBUG := $(shell printf "\e[2D\e[35m")
+INFO  := $(shell printf "\e[2D\e[36m🔵 ")
+OK    := $(shell printf "\e[2D\e[32m🟢 ")
+WARN  := $(shell printf "\e[2D\e[33m🟡 ")
+ERROR := $(shell printf "\e[2D\e[31m🔴 ")
+END   := $(shell printf "\e[0m")
+
+
+.PHONY: default
+default: help
+
+## help - Print help message.
+.PHONY: help
+help: Makefile
+	@echo "usage: make <target>"
+	@sed -n 's/^##//p' $<
+
+## test-data
+testDataDir := eppo/src/test/resources/
+.PHONY: test-data
+test-data: 
+	rm -rf $(testDataDir)
+	mkdir -p $(testDataDir)
+	gsutil cp gs://sdk-test-data/rac-experiments-v2.json $(testDataDir)
+	gsutil cp -r gs://sdk-test-data/assignment-v2 $(testDataDir)
+
+## test
+.PHONY: test
+test: test-data build
+	./gradlew :eppo:testDebugUnitTest
+

--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -26,6 +26,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
 }
 
 ext {}
@@ -34,10 +37,13 @@ ext.versions = [
     "androidx_junit": "1.1.3",
     "gson": "2.9.1",
     "okhttp": "4.10.0",
+    "wiremock": "2.34.0"
 ]
 
 dependencies {
     testImplementation "junit:junit:${versions.junit}"
+    testImplementation "com.github.tomakehurst:wiremock-jre8:${versions.wiremock}"
+
     androidTestImplementation "androidx.test.ext:junit:${versions.androidx_junit}"
     implementation("com.google.code.gson:gson:${versions.gson}")
     implementation("com.squareup.okhttp3:okhttp:${versions.okhttp}")

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationRequestor.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationRequestor.java
@@ -25,7 +25,7 @@ public class ConfigurationRequestor {
     }
 
     public void load(InitializationCallback callback) {
-        client.get("/randomized_assignment/v2/config", new RequestCallback() {
+        client.get("/api/randomized_assignment/v2/config", new RequestCallback() {
             @Override
             public void onSuccess(Reader response) {
                 RandomizationConfigResponse config = gson.fromJson(response, RandomizationConfigResponse.class);

--- a/eppo/src/main/java/cloud/eppo/android/dto/Allocation.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/Allocation.java
@@ -3,10 +3,10 @@ package cloud.eppo.android.dto;
 import java.util.List;
 
 public class Allocation {
-    private int percentExposure;
+    private float percentExposure;
     private List<Variation> variations;
 
-    public int getPercentExposure() {
+    public float getPercentExposure() {
         return percentExposure;
     }
 

--- a/eppo/src/main/java/cloud/eppo/android/exceptions/MissingApiKeyException.java
+++ b/eppo/src/main/java/cloud/eppo/android/exceptions/MissingApiKeyException.java
@@ -1,0 +1,7 @@
+package cloud.eppo.android.exceptions;
+
+public class MissingApiKeyException extends RuntimeException {
+    public MissingApiKeyException() {
+        super("Missing apiKey");
+    }
+}

--- a/eppo/src/test/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/test/java/cloud/eppo/android/EppoClientTest.java
@@ -1,0 +1,126 @@
+package cloud.eppo.android;
+
+import static org.junit.Assert.assertEquals;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import cloud.eppo.android.dto.EppoValue;
+import cloud.eppo.android.dto.SubjectAttributes;
+import cloud.eppo.android.dto.adapters.EppoValueAdapter;
+
+public class EppoClientTest {
+    private static final int TEST_PORT = 4001;
+    private WireMockServer mockServer;
+    private Gson gson = new GsonBuilder().registerTypeAdapter(EppoValue.class, new EppoValueAdapter()).create();
+    private CountDownLatch lock = new CountDownLatch(1);
+
+    static class SubjectWithAttributes {
+        String subjectKey;
+        SubjectAttributes subjectAttributes;
+    }
+
+
+    static class AssignmentTestCase {
+        String experiment;
+        List<SubjectWithAttributes> subjectsWithAttributes;
+        List<String> subjects;
+        List<String> expectedAssignments;
+    }
+
+    @Before
+    public void init() throws InterruptedException {
+        setupMockRacServer();
+
+        new EppoClient.Builder()
+                .apiKey("mock-api-key")
+                .host("http://localhost:4001")
+                .callback(new InitializationCallback() {
+                    @Override
+                    public void onCompleted() {
+                        lock.countDown();
+                    }
+
+                    @Override
+                    public void onError(String errorMessage) {
+                        throw new RuntimeException("Unable to initialize");
+                    }
+                })
+                .buildAndInit();
+
+        lock.await(2000, TimeUnit.MILLISECONDS);
+    }
+
+    @After
+    public void teardown() {
+        this.mockServer.stop();
+    }
+
+    private void setupMockRacServer() {
+        this.mockServer = new WireMockServer(TEST_PORT);
+        this.mockServer.start();
+        String racResponseJson = getMockRandomizedAssignmentResponse();
+        this.mockServer.stubFor(WireMock.get(WireMock.urlMatching(".*randomized_assignment.*")).willReturn(WireMock.okJson(racResponseJson)));
+    }
+
+    @Test
+    public void testAssignments() throws IOException {
+        File testCaseFolder = new File("src/test/resources/assignment-v2/");
+        File[] testCaseFiles = testCaseFolder.listFiles();
+        for (File testCaseFile : testCaseFiles) {
+            runTestCaseFile(testCaseFile);
+        }
+    }
+
+    private void runTestCaseFile(File testCaseFile) throws IOException {
+        String json = FileUtils.readFileToString(testCaseFile, "UTF8");
+        AssignmentTestCase testCase = gson.fromJson(json, AssignmentTestCase.class);
+        List<String> assignments = getAssignments(testCase);
+        assertEquals(testCase.expectedAssignments, assignments);
+    }
+
+    private List<String> getAssignments(AssignmentTestCase testCase) {
+        EppoClient client = EppoClient.getInstance();
+        if (testCase.subjectsWithAttributes != null) {
+            return testCase.subjectsWithAttributes.stream()
+                    .map(subject -> {
+                        try {
+                            return client.getAssignment(subject.subjectKey, testCase.experiment, subject.subjectAttributes);
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    }).collect(Collectors.toList());
+        }
+        return testCase.subjects.stream()
+                .map(subject -> {
+                    try {
+                        return client.getAssignment(subject, testCase.experiment);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }).collect(Collectors.toList());
+    }
+
+    private static String getMockRandomizedAssignmentResponse() {
+        File mockRacResponse = new File("src/test/resources/rac-experiments-v2.json");
+        try {
+            return FileUtils.readFileToString(mockRacResponse, "UTF8");
+        } catch (Exception e) {
+            throw new RuntimeException("Error reading mock RAC data", e);
+        }
+    }
+}


### PR DESCRIPTION
## Description
Adds unit test to verify assignment logic against test data from GCS. 

```
$ make test
...
Finished generating test XML results (0.0 secs) into: eppo/build/test-results/testDebugUnitTest
Generating HTML test report...
Finished generating test html results (0.001 secs) into: /Users/eric/dev/eppo/android-sdk/eppo/build/reports/tests/testDebugUnitTest
:eppo:testDebugUnitTest (Thread[Execution worker for ':' Thread 2,5,main]) completed. Took 0.947 secs.

BUILD SUCCESSFUL in 1s
```

Verified that slight changes to assignment logic led to failed tests (for example, changing the shard range check from `>=` to `>`). 