### PR TITLE
Task for publishing to maven central

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,21 @@ test-data:
 
 ## test
 .PHONY: test
-test: test-data build
+test: test-data
 	./gradlew :eppo:testDebugUnitTest
+
+.PHONY: publish-release
+publish-release: test
+		# $(INFO)Checking required gradle configuration(END)
+		@for required_property in "MAVEN_USERNAME" "MAVEN_PASSWORD"; do \
+				cat ~/.gradle/gradle.properties | grep -q $$required_property; \
+				if [ $$? != 0 ]; then \
+						echo "$(ERROR)ERROR: ~/.gradle/gradle.properties file is missing property: $$required_property$(END)"; \
+						exit 1; \
+				fi; \
+		done
+
+		# $(INFO)Publishing release(END)
+		./gradlew :eppo:publishReleasePublicationToMavenRepository
+
 

--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.android.library'
+    id 'maven-publish'
 }
 
 group = "cloud.eppo"
@@ -47,4 +48,51 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit:${versions.androidx_junit}"
     implementation("com.google.code.gson:gson:${versions.gson}")
     implementation("com.squareup.okhttp3:okhttp:${versions.okhttp}")
+}
+
+publishing {
+    publications {
+        release(MavenPublication) {
+            groupId = 'cloud.eppo'
+            artifactId = 'android-sdk'
+            version = '0.0.1'
+
+            afterEvaluate {
+                from components.release
+            }
+
+            pom {
+                name = 'Eppo Android'
+                description = 'Eppo Android SDK'
+                url = 'https://github.com/Eppo-exp/android-sdk'
+                licenses {
+                    license {
+                        name = 'MIT License'
+                        url = 'http://www.opensource.org/licenses/mit-license.php'
+                    }
+                }
+                developers {
+                    developer {
+                        name = 'Eppo'
+                        email = 'https://www.geteppo.com'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:git://github.com/Eppo-exp/android-sdk.git'
+                    developerConnection = 'scm:git:ssh://github.com/Eppo-exp/android-sdk.git'
+                    url = 'https://github.com/Eppo-exp/android-sdk/tree/main'
+                }
+            }
+        }
+    }
+    repositories {
+        maven {
+            credentials {
+                username = "$MAVEN_USERNAME"
+                password = "$MAVEN_PASSWORD"
+            }
+
+            url = "https://s01.oss.sonatype.org/content/repositories/releases"
+        }
+    }
 }


### PR DESCRIPTION
## Description
Adds a gradle task for publishing releases to Maven Central. 

Requires `MAVEN_USERNAME` and `MAVEN_PASSWORD` Gradle properties to be set. 
