### PR TITLE
Cache configuration locally to disk and SharedPreferences for early accessed flags

### DIFF
--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "cloud.eppo"
-version = "0.1.2"
+version = "0.1.3"
 
 android {
     compileSdk 30
@@ -57,6 +57,8 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit:${versions.androidx_junit}"
     implementation("com.google.code.gson:gson:${versions.gson}")
     implementation("com.squareup.okhttp3:okhttp:${versions.okhttp}")
+
+    implementation 'androidx.security:security-crypto:1.1.0-alpha03'
 }
 
 publishing {

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationRequestor.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationRequestor.java
@@ -2,23 +2,17 @@ package cloud.eppo.android;
 
 import android.util.Log;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 
 import java.io.Reader;
 
-import cloud.eppo.android.dto.EppoValue;
-import cloud.eppo.android.dto.adapters.EppoValueAdapter;
 import cloud.eppo.android.dto.FlagConfig;
-import cloud.eppo.android.dto.RandomizationConfigResponse;
 
 public class ConfigurationRequestor {
     private static final String TAG = ConfigurationRequestor.class.getCanonicalName();
 
     private EppoHttpClient client;
     private ConfigurationStore configurationStore;
-    private Gson gson = new GsonBuilder().registerTypeAdapter(EppoValue.class, new EppoValueAdapter()).create();
 
     public ConfigurationRequestor(ConfigurationStore configurationStore, EppoHttpClient client) {
         this.configurationStore = configurationStore;
@@ -26,12 +20,13 @@ public class ConfigurationRequestor {
     }
 
     public void load(InitializationCallback callback) {
+        boolean usedCache = configurationStore.loadFromCache(callback);
+
         client.get("/api/randomized_assignment/v2/config", new RequestCallback() {
             @Override
             public void onSuccess(Reader response) {
                 try {
-                    RandomizationConfigResponse config = gson.fromJson(response, RandomizationConfigResponse.class);
-                    configurationStore.setFlags(config.getFlags());
+                    configurationStore.setFlags(response);
                 } catch (JsonSyntaxException e) {
                     // JsonSyntaxException is thrown in cases when a SocketException occurs
                     Log.e(TAG, "Error loading configuration response", e);
@@ -41,7 +36,7 @@ public class ConfigurationRequestor {
                     return;
                 }
 
-                if (callback != null) {
+                if (callback != null && !usedCache) {
                     callback.onCompleted();
                 }
             }
@@ -49,7 +44,7 @@ public class ConfigurationRequestor {
             @Override
             public void onFailure(String errorMessage) {
                 Log.e(TAG, errorMessage);
-                if (callback != null) {
+                if (callback != null && !usedCache) {
                     callback.onError(errorMessage);
                 }
             }

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
@@ -1,24 +1,159 @@
 package cloud.eppo.android;
 
-import java.util.Map;
+import android.app.Application;
+import android.content.SharedPreferences;
+import android.os.AsyncTask;
+import android.util.Log;
 
+import androidx.security.crypto.EncryptedFile;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import java.io.File;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import cloud.eppo.android.dto.EppoValue;
 import cloud.eppo.android.dto.FlagConfig;
+import cloud.eppo.android.dto.RandomizationConfigResponse;
+import cloud.eppo.android.dto.adapters.EppoValueAdapter;
+import cloud.eppo.android.util.Utils;
 
 public class ConfigurationStore {
 
-    private Map<String, FlagConfig> flags;
+    private static final String CACHE_FILE_NAME = "eppo-sdk-config.enc";
+    private static final String TAG = ConfigurationStore.class.getSimpleName();
 
-    public void setFlags(Map<String, FlagConfig> flags) {
-        this.flags = flags;
+    private final Gson gson = new GsonBuilder().registerTypeAdapter(EppoValue.class, new EppoValueAdapter()).create();
+    private final Set<String> flagConfigsToSaveToPrefs = new HashSet<>();
+    private final File filesDir;
+    private final SharedPreferences sharedPrefs;
 
-        // TODO persist to local file (for use when offline/before new config loads)
+    private ConcurrentHashMap<String, FlagConfig> flags;
+    private EncryptedFile configCacheFile;
+
+    public ConfigurationStore(Application application) {
+        filesDir = application.getFilesDir();
+
+        try {
+            this.configCacheFile = Utils.getSecureFile(CACHE_FILE_NAME, application);
+        } catch (Exception e) {
+            Log.e(TAG, "Unable to create secure cache file", e);
+        }
+        this.sharedPrefs = Utils.getSharedPrefs(application);
+    }
+
+    public boolean loadFromCache(InitializationCallback callback) {
+        if (flags != null) {
+            return false;
+        }
+
+        AsyncTask.execute(() -> {
+            try {
+                synchronized (configCacheFile) {
+                    InputStreamReader reader = new InputStreamReader(configCacheFile.openFileInput());
+                    RandomizationConfigResponse configResponse = gson.fromJson(reader, RandomizationConfigResponse.class);
+                    reader.close();
+                    flags = configResponse.getFlags();
+                }
+            } catch (Exception e) {
+                Log.e(TAG, "Error loading from local cache", e);
+                deleteConfigCacheFile();
+
+                if (callback != null) {
+                    callback.onError("Unable to load config from cache");
+                }
+            }
+
+            if (callback != null) {
+                callback.onCompleted();
+            }
+        });
+        return true;
+    }
+
+    public void setFlags(Reader response) {
+        RandomizationConfigResponse config = gson.fromJson(response, RandomizationConfigResponse.class);
+        flags = config.getFlags();
+
+        // update any existing flags already in shared prefs
+        updateConfigsInSharedPrefs();
+
+        if (!flagConfigsToSaveToPrefs.isEmpty()) {
+            SharedPreferences.Editor editor = sharedPrefs.edit();
+            for (String flagKey : flagConfigsToSaveToPrefs) {
+                FlagConfig flagConfig = getFlag(flagKey);
+                if (flagConfig == null) {
+                    continue;
+                }
+                writeFlagToSharedPrefs(flagKey, flagConfig, editor);
+            }
+            editor.apply();
+            flagConfigsToSaveToPrefs.clear();
+        }
+
+        writeConfigToFile(config);
+    }
+
+    private void updateConfigsInSharedPrefs() {
+        SharedPreferences.Editor editor = sharedPrefs.edit();
+        for (String flagKey : flags.keySet()) {
+            if (sharedPrefs.contains(flagKey)) {
+                writeFlagToSharedPrefs(flagKey, flags.get(flagKey), editor);
+            }
+        }
+        editor.apply();
+    }
+
+    private void writeFlagToSharedPrefs(String flagKey, FlagConfig config, SharedPreferences.Editor editor) {
+        editor.putString(flagKey, gson.toJson(config));
+    }
+
+    private void writeConfigToFile(RandomizationConfigResponse config) {
+        AsyncTask.execute(() -> {
+            try {
+                synchronized (configCacheFile) {
+                    deleteConfigCacheFile(); // EncryptedFile requires deleting old versions if one exists
+                    OutputStreamWriter writer = new OutputStreamWriter(configCacheFile.openFileOutput());
+                    gson.toJson(config, writer);
+                    writer.close();
+                }
+            } catch (Exception e) {
+                Log.e(TAG, "Unable to cache config to file", e);
+            }
+        });
+    }
+
+    private void deleteConfigCacheFile() {
+        File existingFile = new File(filesDir + File.separator + CACHE_FILE_NAME);
+        if (existingFile.exists()) {
+            existingFile.delete();
+        }
+    }
+
+    private FlagConfig getFlagFromSharedPrefs(String flagKey) {
+        try {
+            return gson.fromJson(sharedPrefs.getString(flagKey, null), FlagConfig.class);
+        } catch (Exception e) {
+            Log.e(TAG, "Unable to load flag from prefs", e);
+        }
+        return null;
     }
 
     public FlagConfig getFlag(String flagKey) {
         if (flags == null) {
+            FlagConfig flagFromSharedPrefs = getFlagFromSharedPrefs(flagKey);
+            if (flagFromSharedPrefs != null) {
+                return flagFromSharedPrefs;
+            }
+            flagConfigsToSaveToPrefs.add(flagKey);
             return null;
         }
         return flags.get(flagKey);
     }
-
 }

--- a/eppo/src/main/java/cloud/eppo/android/dto/RandomizationConfigResponse.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/RandomizationConfigResponse.java
@@ -1,11 +1,11 @@
 package cloud.eppo.android.dto;
 
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class RandomizationConfigResponse {
-    private Map<String, FlagConfig> flags;
+    private ConcurrentHashMap<String, FlagConfig> flags;
 
-    public Map<String, FlagConfig> getFlags() {
+    public ConcurrentHashMap<String, FlagConfig> getFlags() {
         return flags;
     }
 }

--- a/eppo/src/main/java/cloud/eppo/android/exceptions/MissingApplicationException.java
+++ b/eppo/src/main/java/cloud/eppo/android/exceptions/MissingApplicationException.java
@@ -1,0 +1,7 @@
+package cloud.eppo.android.exceptions;
+
+public class MissingApplicationException extends RuntimeException {
+    public MissingApplicationException() {
+        super("Missing context");
+    }
+}

--- a/eppo/src/main/java/cloud/eppo/android/util/Utils.java
+++ b/eppo/src/main/java/cloud/eppo/android/util/Utils.java
@@ -1,6 +1,16 @@
 package cloud.eppo.android.util;
 
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.security.crypto.EncryptedFile;
+import androidx.security.crypto.EncryptedSharedPreferences;
+import androidx.security.crypto.MasterKey;
+
+import java.io.File;
+import java.io.IOException;
 import java.math.BigInteger;
+import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.DateFormat;
@@ -51,5 +61,37 @@ public class Utils {
         DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
         df.setTimeZone(tz);
         return df.format(date);
+    }
+
+    public static SharedPreferences getSharedPrefs(Context context) {
+        try {
+            MasterKey masterKey = new MasterKey.Builder(context)
+                    .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                    .build();
+
+            return EncryptedSharedPreferences.create(
+                    context,
+                    "eppo-enc",
+                    masterKey,
+                    EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+            );
+        } catch (Exception e) {
+            return context.getSharedPreferences("eppo", Context.MODE_PRIVATE);
+        }
+    }
+
+    public static EncryptedFile getSecureFile(String fileName, Context context) throws GeneralSecurityException, IOException {
+        MasterKey masterKey = new MasterKey.Builder(context)
+                .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                .build();
+
+        File file = new File(context.getFilesDir(), fileName);
+        return new EncryptedFile.Builder(
+                context,
+                file,
+                masterKey,
+                EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB
+        ).build();
     }
 }


### PR DESCRIPTION
## Description
In order for the SDK to assign users to experiments or check a flag's status, the configuration must be loaded from a remote server. If a flag is evaluated before the configuration is loaded, `null` is returned. This can also result in the same user seeing different experiences for the same flag/experiment, even if no configurations have changed, due to network delays. 

This PR adds multiple levels of caching which will reduce these occurrences. 

#### File Cache
The first level of caching is an encrypted file which stores the entirety of the remote config. The file is loaded asynchronously when the SDK is initialized. If a cached version of the config exists, the `InitializationCallback` will be called only once when the cached version is loaded, even though the response from network will replace the configuration in memory (as well as replace the cache file with the new version). 

#### SharedPreferences Cache
The cached file can still lead to cases where a flag is evaluated as `null` if one is evaluated before the file is read (since it is read asynchronously/off of the main thread). Whenever the SDK detects that a flag was evaluated before the configuration is loaded, it will then save that flag's config to `EncryptedSharedPreferences` (falling back to `SharedPreferences` if necessary) once it is available. Any time a flag evaluation is performed before the entire config is loaded from the disk/network, it will check the `SharedPreferences` for the flag's configuration and use it if one is available. 