### PR TITLE
Run `EppoClient` tests on device/emulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ lint/tmp/
 .idea/*
 
 eppo/src/test/resources/*
+eppo/src/androidTest/assets/*

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ help: Makefile
 	@sed -n 's/^##//p' $<
 
 ## test-data
-testDataDir := eppo/src/test/resources/
+testDataDir := eppo/src/androidTest/assets/
 .PHONY: test-data
 test-data: 
 	rm -rf $(testDataDir)
@@ -36,7 +36,7 @@ test-data:
 ## test
 .PHONY: test
 test: test-data
-	./gradlew :eppo:testDebugUnitTest
+	./gradlew runEppoTests
 
 .PHONY: publish-release
 publish-release: test

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.2.2' apply false
-    id 'com.android.library' version '7.2.2' apply false
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
 }
 
 task clean(type: Delete) {

--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -7,11 +7,17 @@ group = "cloud.eppo"
 version = "0.1.3"
 
 android {
-    compileSdk 30
+    compileSdk 33
 
     defaultConfig {
-        minSdk 21
-        targetSdk 30
+        gradle.startParameter.taskNames.each {
+            if (it.contains("AndroidTest")) {
+                minSdk 33 // required to use wiremock in tests
+            } else {
+                minSdk 21
+            }
+        }
+        targetSdk 33
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -24,11 +30,13 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             buildConfigField "String", EPPO_VERSION, "\"${project.properties.get("version")}\""
+            matchingFallbacks = ['release']
         }
 
         debug {
             minifyEnabled false
             buildConfigField "String", EPPO_VERSION, "\"${project.properties.get("version")}\""
+            matchingFallbacks = ['debug']
         }
     }
     compileOptions {
@@ -38,12 +46,17 @@ android {
     testOptions {
         unitTests.returnDefaultValues = true
     }
+    packagingOptions {
+        exclude("META-INF/**")
+    }
 }
 
 ext {}
 ext.versions = [
     "junit": "4.13.2",
     "androidx_junit": "1.1.3",
+    "androidx_core": "1.5.0",
+    "androidx_runner": "1.5.2",
     "gson": "2.9.1",
     "okhttp": "4.10.0",
     "wiremock": "2.34.0"
@@ -52,9 +65,11 @@ ext.versions = [
 
 dependencies {
     testImplementation "junit:junit:${versions.junit}"
-    testImplementation "com.github.tomakehurst:wiremock-jre8:${versions.wiremock}"
-
+    androidTestImplementation "com.github.tomakehurst:wiremock-jre8:${versions.wiremock}"
     androidTestImplementation "androidx.test.ext:junit:${versions.androidx_junit}"
+    androidTestImplementation "androidx.test:core:${versions.androidx_core}"
+    androidTestImplementation "androidx.test:runner:${versions.androidx_runner}"
+
     implementation("com.google.code.gson:gson:${versions.gson}")
     implementation("com.squareup.okhttp3:okhttp:${versions.okhttp}")
 
@@ -106,4 +121,11 @@ publishing {
             url = "https://s01.oss.sonatype.org/content/repositories/releases"
         }
     }
+}
+
+task runEppoTests(type: GradleBuild) {
+    tasks = [
+        ':eppo:testDebugUnitTest',
+        ':eppo:connectedDebugAndroidTest'
+    ]
 }

--- a/eppo/src/androidTest/AndroidManifest.xml
+++ b/eppo/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    package="cloud.eppo.android"
+    >
+
+    <application android:usesCleartextTraffic="true" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
+</manifest>

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
@@ -49,7 +49,7 @@ public class ConfigurationStore {
     }
 
     public boolean loadFromCache(InitializationCallback callback) {
-        if (flags != null) {
+        if (flags != null || !new File(filesDir + File.separator + CACHE_FILE_NAME).exists()) {
             return false;
         }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Sep 06 11:52:39 CEST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Description
PR #10 add an additional required `Application` parameter to SDK initialization. In order to obtain an `Application` instance in our tests, we need to run the tests on an Android device/emulator. This PR moves the `EppoClientTest` to `androidTest`, and some other changes required for the tests to run on a device/emulator. 