### PR TITLE
upgrade androidx.security package to pick up bug fixes

### DIFF
--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "cloud.eppo"
-version = "0.1.4"
+version = "0.1.5"
 
 android {
     compileSdk 33
@@ -73,7 +73,7 @@ dependencies {
     implementation("com.google.code.gson:gson:${versions.gson}")
     implementation("com.squareup.okhttp3:okhttp:${versions.okhttp}")
 
-    implementation 'androidx.security:security-crypto:1.1.0-alpha03'
+    implementation 'androidx.security:security-crypto:1.1.0-alpha05'
 }
 
 publishing {


### PR DESCRIPTION
A user reported the following Application Not Responding (ANR): 
```
at sun.misc.Unsafe.park(Unsafe.java)
at java.util.concurrent.locks.LockSupport.park(LockSupport.java:190)
at java.util.concurrent.CompletableFuture$Signaller.block(CompletableFuture.java:1723)
at java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3446)
at java.util.concurrent.CompletableFuture.waitingGet(CompletableFuture.java:1752)
at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1923)
at android.security.KeyStore.interruptedPreservingGet(KeyStore.java:1396)
at android.security.KeyStore.update(KeyStore.java:897)
at android.security.keystore.KeyStoreCryptoOperationChunkedStreamer$MainDataStream.update(KeyStoreCryptoOperationChunkedStreamer.java:227)
at android.security.keystore.KeyStoreCryptoOperationChunkedStreamer.update(KeyStoreCryptoOperationChunkedStreamer.java:134)
at android.security.keystore.KeyStoreCryptoOperationChunkedStreamer.doFinal(KeyStoreCryptoOperationChunkedStreamer.java:179)
at android.security.keystore.AndroidKeyStoreAuthenticatedAESCipherSpi$BufferAllOutputUntilDoFinalStreamer.doFinal(AndroidKeyStoreAuthenticatedAESCipherSpi.java:373)
at android.security.keystore.AndroidKeyStoreCipherSpiBase.engineDoFinal(AndroidKeyStoreCipherSpiBase.java:506)
at javax.crypto.Cipher.doFinal(Cipher.java:2113)
at com.google.crypto.tink.integration.android.AndroidKeystoreAesGcm.decryptInternal(AndroidKeystoreAesGcm.java:115)
at com.google.crypto.tink.integration.android.AndroidKeystoreAesGcm.decrypt(AndroidKeystoreAesGcm.java:97)
at com.google.crypto.tink.KeysetHandle.decrypt(KeysetHandle.java:206)
at com.google.crypto.tink.KeysetHandle.read(KeysetHandle.java:107)
at com.google.crypto.tink.integration.android.AndroidKeysetManager$Builder.read(AndroidKeysetManager.java:311)
at com.google.crypto.tink.integration.android.AndroidKeysetManager$Builder.readOrGenerateNewKeyset(AndroidKeysetManager.java:287)
at com.google.crypto.tink.integration.android.AndroidKeysetManager$Builder.build(AndroidKeysetManager.java:238)
at androidx.security.crypto.EncryptedFile$Builder.build(EncryptedFile.java:200)
at cloud.eppo.android.util.Utils.getSecureFile(Utils.java:95)
at cloud.eppo.android.ConfigurationStore.<init>(ConfigurationStore.java:47)
at cloud.eppo.android.EppoClient.<init>(EppoClient.java:35)
at cloud.eppo.android.EppoClient.init(EppoClient.java:53)
at cloud.eppo.android.EppoClient$Builder.buildAndInit(EppoClient.java:177)
...
```

This is due to this issue in Android's issue tracker: [Race condition when building EncryptedFile from multiple threads with no pre-existing keyset ](https://issuetracker.google.com/issues/136590547?pli=1)

A fix for this issue has been included in the latest version of the `androidx.security` package. 