### PR TITLE
Update `androidx.security:security-crypto` to `1.1.0-alpha06`

### DIFF
--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "cloud.eppo"
-version = "0.2.0"
+version = "0.2.1"
 
 android {
     compileSdk 33
@@ -73,7 +73,7 @@ dependencies {
     implementation("com.google.code.gson:gson:${versions.gson}")
     implementation("com.squareup.okhttp3:okhttp:${versions.okhttp}")
 
-    implementation 'androidx.security:security-crypto:1.1.0-alpha05'
+    implementation 'androidx.security:security-crypto:1.1.0-alpha06'
 }
 
 publishing {


### PR DESCRIPTION
### Description
Updates `androidx.security:security-crypto` to version `1.1.0-alpha06` [Release notes](https://developer.android.com/jetpack/androidx/releases/security#version_110_2)

Notable changes in this update include an upgrade to transitive dependency Tink to version 1.8.0 [Release notes](https://github.com/tink-crypto/tink-java/releases/tag/v1.8.0), which contains a fix for a bug causing ANRs. 