### PR TITLE
Added allocation id in the assignment logging data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ test-data:
 .PHONY: test
 test: test-data
 	# $(INFO)Uninstalling old version of test app(END)
-	# adb uninstall cloud.eppo.android.test
+	adb uninstall cloud.eppo.android.test
 	# $(INFO)Running tests(END)
 	./gradlew runEppoTests
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ help: Makefile
 	@sed -n 's/^##//p' $<
 
 ## test-data
-testDataDir := eppo/src/androidTest/assets/
+testDataDir := eppo/src/androidTest/assets
 tempDir := ${testDataDir}/temp
 gitDataDir := ${tempDir}/sdk-test-data
 branchName := main
@@ -46,7 +46,7 @@ test-data:
 .PHONY: test
 test: test-data
 	# $(INFO)Uninstalling old version of test app(END)
-	adb uninstall cloud.eppo.android.test
+	# adb uninstall cloud.eppo.android.test
 	# $(INFO)Running tests(END)
 	./gradlew runEppoTests
 

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -122,7 +122,8 @@ public class EppoClient {
             return null;
         }
 
-        Allocation allocation = flag.getAllocations().get(rule.getAllocationKey());
+        String allocationKey = rule.getAllocationKey();
+        Allocation allocation = flag.getAllocations().get(allocationKey);
         if (!isInExperimentSample(subjectKey, flagKey, flag.getSubjectShards(), allocation.getPercentExposure())) {
             Log.i(TAG, "no assigned variation. The subject is not part of the sample population");
             return null;
@@ -135,9 +136,10 @@ public class EppoClient {
         }
 
         if (assignmentLogger != null) {
-            Assignment assignment = new Assignment(flagKey,
-                    assignedVariation.getTypedValue().stringValue(), subjectKey,
-                    Utils.getISODate(new Date()), subjectAttributes);
+            String experimentKey = Utils.generateExperimentKey(flagKey, allocationKey);
+            Assignment assignment = new Assignment(experimentKey,
+                    flagKey, allocationKey, assignedVariation.getTypedValue().stringValue(),
+                    subjectKey, Utils.getISODate(new Date()), subjectAttributes);
             assignmentLogger.logAssignment(assignment);
         }
 

--- a/eppo/src/main/java/cloud/eppo/android/logging/Assignment.java
+++ b/eppo/src/main/java/cloud/eppo/android/logging/Assignment.java
@@ -4,13 +4,25 @@ import cloud.eppo.android.dto.SubjectAttributes;
 
 public class Assignment {
     private String experiment;
+    private String featureFlag;
+    private String allocation;
     private String variation;
     private String subject;
     private String timestamp;
     private SubjectAttributes subjectAttributes;
 
-    public Assignment(String experiment, String variation, String subject, String timestamp, SubjectAttributes subjectAttributes) {
+    public Assignment(
+            String experiment,
+            String featureFlag,
+            String allocation,
+            String variation,
+            String subject,
+            String timestamp,
+            SubjectAttributes subjectAttributes
+    ) {
         this.experiment = experiment;
+        this.featureFlag = featureFlag;
+        this.allocation = allocation;
         this.variation = variation;
         this.subject = subject;
         this.timestamp = timestamp;

--- a/eppo/src/main/java/cloud/eppo/android/util/Utils.java
+++ b/eppo/src/main/java/cloud/eppo/android/util/Utils.java
@@ -63,15 +63,6 @@ public class Utils {
     }
 
     public static String generateExperimentKey(String featureFlagKey, String allocationKey) {
-        String encodedAllocationKey = "";
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            encodedAllocationKey = Base64.getEncoder().encodeToString(allocationKey.getBytes());
-        } else {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.FROYO) {
-                encodedAllocationKey =  android.util.Base64.encodeToString(allocationKey.getBytes(), android.util.Base64.DEFAULT);
-            }
-        }
-
-        return featureFlagKey + '|' + encodedAllocationKey;
+        return featureFlagKey + '-' + allocationKey;
     }
 }

--- a/eppo/src/main/java/cloud/eppo/android/util/Utils.java
+++ b/eppo/src/main/java/cloud/eppo/android/util/Utils.java
@@ -2,12 +2,14 @@ package cloud.eppo.android.util;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Build;
 
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Base64;
 import java.util.Date;
 import java.util.TimeZone;
 
@@ -58,5 +60,18 @@ public class Utils {
 
     public static SharedPreferences getSharedPrefs(Context context) {
         return context.getSharedPreferences("eppo", Context.MODE_PRIVATE);
+    }
+
+    public static String generateExperimentKey(String featureFlagKey, String allocationKey) {
+        String encodedAllocationKey = "";
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            encodedAllocationKey = Base64.getEncoder().encodeToString(allocationKey.getBytes());
+        } else {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.FROYO) {
+                encodedAllocationKey =  android.util.Base64.encodeToString(allocationKey.getBytes(), android.util.Base64.DEFAULT);
+            }
+        }
+
+        return featureFlagKey + '|' + encodedAllocationKey;
     }
 }


### PR DESCRIPTION
Made below changes in the code.
- removed extra `/` from make file 
- Added helper function `generateExperimentKey` to generate experiment key in `Utils`
- Modified the`Assignment` dto class, added two new field featureFlag and allocation.
- Initialise featureFlag and allocation with feature flag key and allocation key respectively while calling assignment log callback.

<img width="1790" alt="Screenshot 2023-09-01 at 3 23 22 PM" src="https://github.com/Eppo-exp/android-sdk/assets/29010006/19beb1a9-9f93-4589-aaa5-b2c701960c73">
