### PR TITLE
Aadded workflow for publishing SDK

### DIFF
--- a/.github/workflows/publish-sdk.yaml
+++ b/.github/workflows/publish-sdk.yaml
@@ -1,8 +1,7 @@
 name: Publish Android SDK
 on:
-  pull_request:
-    paths:
-      - '**/*'
+  release:
+    types: [published]
 
 env:
   ANDROID_API_LEVEL: 33

--- a/.github/workflows/publish-sdk.yaml
+++ b/.github/workflows/publish-sdk.yaml
@@ -1,0 +1,35 @@
+name: Publish Android SDK
+on:
+  pull_request:
+    paths:
+      - '**/*'
+
+env:
+  ANDROID_API_LEVEL: 33
+
+jobs:
+  lint-test-sdk:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+
+      - name: Restore gradle.properties
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_USERNAME }}
+        shell: bash
+        run: |
+          mkdir -p ~/.gradle/
+          echo "GRADLE_USER_HOME=${HOME}/.gradle" >> $GITHUB_ENV
+          echo "MAVEN_USERNAME=${MAVEN_USERNAME}" > ~/.gradle/gradle.properties
+          echo "MAVEN_PASSWORD=${MAVEN_PASSWORD}" >> ~/.gradle/gradle.properties
+
+      - name: Publish
+        run: make publish-release-without-test

--- a/.github/workflows/publish-sdk.yaml
+++ b/.github/workflows/publish-sdk.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Restore gradle.properties
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
         shell: bash
         run: |
           mkdir -p ~/.gradle/

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ check-maven-credentials-and-publish:
 .PHONY: publish-release
 publish-release: test check-maven-credentials-and-publish
 
+# todo: remove this command when test workflow is ready and use publish-release instead
 .PHONY: publish-release-without-test
 publish-release-without-test:check-maven-credentials-and-publish
 

--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,8 @@ test: test-data
 	# $(INFO)Running tests(END)
 	./gradlew runEppoTests
 
-.PHONY: publish-release
-publish-release: test
-		# $(INFO)Checking required gradle configuration(END)
+check-maven-credentials-and-publish:
+	# $(INFO)Checking required gradle configuration(END)
 		@for required_property in "MAVEN_USERNAME" "MAVEN_PASSWORD"; do \
 				cat ~/.gradle/gradle.properties | grep -q $$required_property; \
 				if [ $$? != 0 ]; then \
@@ -64,4 +63,9 @@ publish-release: test
 		# $(INFO)Publishing release(END)
 		./gradlew :eppo:publishReleasePublicationToMavenRepository
 
+.PHONY: publish-release
+publish-release: test check-maven-credentials-and-publish
+
+.PHONY: publish-release-without-test
+publish-release-without-test:check-maven-credentials-and-publish
 


### PR DESCRIPTION
- Added new publish command (`publish-release-without-test`) in make file to by pass the test step for now
- Added workflow ymal file

Ran the workflow with incorrect credential to test the setting. It failed at the last step due to incorrect credential. 
<img width="1414" alt="Screenshot 2023-09-05 at 2 55 30 PM" src="https://github.com/Eppo-exp/android-sdk/assets/29010006/9ea761fa-681f-41bf-86cd-e5f16274914c">
