### PR TITLE
add support for getJSONStringAssignment and getParsedJSONAssignment (FF-918)

### DIFF
--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -28,7 +28,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Type;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -230,9 +229,12 @@ public class EppoClientTest {
                 assertEquals(expectedBooleanAssignments, actualBooleanAssignments);
                 return actualBooleanAssignments.size();
             case JSON:
-                List<String> actualJSONAssignments = this.getJSONAssignments(testCase);
-                assertEquals(testCase.expectedAssignments, actualJSONAssignments);
-                return actualJSONAssignments.size();
+                // test parsed json
+                List<JsonElement> actualParsedJSONAssignments = this.getJSONAssignments(testCase);
+                List<String> actualJSONStringAssignments = actualParsedJSONAssignments.stream().map(x -> x.toString()).collect(Collectors.toList());
+
+                assertEquals(testCase.expectedAssignments, actualJSONStringAssignments);
+                return actualParsedJSONAssignments.size();
             default:
                 List<String> actualStringAssignments = this.getStringAssignments(testCase);
                 assertEquals(testCase.expectedAssignments, actualStringAssignments);
@@ -254,7 +256,7 @@ public class EppoClientTest {
                                     return client.getBooleanAssignment(subject.subjectKey, testCase.experiment,
                                             subject.subjectAttributes);
                                 case JSON:
-                                    return client.getJSONAssignment(subject.subjectKey, testCase.experiment,
+                                    return client.getParsedJSONAssignment(subject.subjectKey, testCase.experiment,
                                             subject.subjectAttributes);
                                 default:
                                     return client.getStringAssignment(subject.subjectKey, testCase.experiment,
@@ -274,7 +276,7 @@ public class EppoClientTest {
                             case BOOLEAN:
                                 return client.getBooleanAssignment(subject, testCase.experiment);
                             case JSON:
-                                return client.getJSONAssignment(subject, testCase.experiment);
+                                return client.getParsedJSONAssignment(subject, testCase.experiment);
                             default:
                                 return client.getStringAssignment(subject, testCase.experiment);
                         }
@@ -296,8 +298,8 @@ public class EppoClientTest {
         return (List<Boolean>) this.getAssignments(testCase, AssignmentValueType.BOOLEAN);
     }
 
-    private List<String> getJSONAssignments(AssignmentTestCase testCase) {
-        return (List<String>) this.getAssignments(testCase, AssignmentValueType.JSON);
+    private List<JsonElement> getJSONAssignments(AssignmentTestCase testCase) {
+        return (List<JsonElement>) this.getAssignments(testCase, AssignmentValueType.JSON);
     }
 
     private static String getMockRandomizedAssignmentResponse() {

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -7,12 +7,13 @@ import android.app.Application;
 import android.os.Build;
 import android.util.Log;
 
+import com.google.gson.JsonElement;
+
 import java.util.Date;
 import java.util.List;
 
 import cloud.eppo.android.dto.Allocation;
 import cloud.eppo.android.dto.EppoValue;
-import cloud.eppo.android.dto.EppoValueType;
 import cloud.eppo.android.dto.FlagConfig;
 import cloud.eppo.android.dto.SubjectAttributes;
 import cloud.eppo.android.dto.TargetingRule;
@@ -193,17 +194,25 @@ public class EppoClient {
         return this.getDoubleAssignment(subjectKey, flagKey, new SubjectAttributes());
     }
 
-    public String getJSONAssignment(String subjectKey, String flagKey, SubjectAttributes subjectAttributes) {
+    public String getJSONStringAssignment(String subjectKey, String flagKey, SubjectAttributes subjectAttributes) {
+        return this.getParsedJSONAssignment(subjectKey, flagKey, subjectAttributes).toString();
+    }
+
+    public String getJSONStringAssignment(String subjectKey, String flagKey) {
+        return this.getParsedJSONAssignment(subjectKey, flagKey, new SubjectAttributes()).toString();
+    }
+
+    public JsonElement getParsedJSONAssignment(String subjectKey, String flagKey, SubjectAttributes subjectAttributes) {
         EppoValue value = this.getTypedAssignment(subjectKey, flagKey, subjectAttributes);
         if (value == null) {
             return null;
         }
 
-        return value.jsonValue().toString();
+        return value.jsonValue();
     }
 
-    public String getJSONAssignment(String subjectKey, String flagKey) {
-        return this.getJSONAssignment(subjectKey, flagKey, new SubjectAttributes());
+    public JsonElement getParsedJSONAssignment(String subjectKey, String flagKey) {
+        return this.getParsedJSONAssignment(subjectKey, flagKey, new SubjectAttributes());
     }
 
     public static EppoClient getInstance() throws NotInitializedException {


### PR DESCRIPTION
## description

* renames `getJSONAssignment -> getJSONStringAssignment` for clarity and consistency across SDKs
* adds `getParsedJSONAssignment` method returning a `JsonElement` from the `Gson` library

## test

Ran locally against an emulator:

```
> Task :eppo:eppo:connectedDebugAndroidTest
Starting 2 tests on Pixel_7_API_34(AVD) - 14

BUILD SUCCESSFUL in 13s
1 actionable task: 1 executed
```