### PR TITLE
rename project to Eppo SDK

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -12,6 +12,6 @@ dependencyResolutionManagement {
         mavenCentral()
     }
 }
-rootProject.name = "Eppo Example"
+rootProject.name = "Eppo SDK"
 include ':example'
 include ':eppo'


### PR DESCRIPTION
## motivation

This has been bugging me. I don't think there is anything customer impacting here as we don't publish this SDK into the android app store but I wanted to get the metadata tidied. up.

<img width="659" alt="Screenshot 2023-10-20 at 9 38 11 AM" src="https://github.com/Eppo-exp/android-sdk/assets/57361/f5db80ef-a178-4a34-b856-7f4a60f26dda">

## description

<img width="659" alt="Screenshot 2023-10-20 at 9 37 42 AM" src="https://github.com/Eppo-exp/android-sdk/assets/57361/028f2e21-f06f-4bc0-8363-cad073804cd7">
