### PR TITLE
fix gradlew connectedCheck to run locally; update example app to min sdk 33

### DIFF
--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -11,7 +11,7 @@ android {
 
     defaultConfig {
         gradle.startParameter.taskNames.each {
-            if (it.contains("AndroidTest")) {
+            if (it.contains("AndroidTest") || it.contains('connectedCheck')) {
                 minSdk 33 // required to use wiremock in tests
             } else {
                 minSdk 21

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -7,7 +7,7 @@ android {
 
     defaultConfig {
         applicationId "cloud.eppo.androidexample"
-        minSdk 21
+        minSdk 33
         targetSdk 33
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
…sdk 33

## context

```
➜  android-sdk git:(main) ./gradlew connectedCheck

> Configure project :eppo
WARNING:Software Components will not be created automatically for Maven publishing from Android Gradle Plugin 8.0. To opt-in to the future behavior, set the Gradle property android.disableAutomaticComponentCreation=true in the `gradle.properties` file or use the new publishing DSL.

> Task :eppo:mergeExtDexDebugAndroidTest
ERROR:/Users/leo/.gradle/caches/modules-2/files-2.1/org.eclipse.jetty/jetty-servlet/9.4.48.v20220622/8a9a53e0aad3f194a4cc9940f7e9d5619254bf62/jetty-servlet-9.4.48.v20220622.jar: D8: com.android.tools.r8.internal.k2: MethodHandle.invoke and MethodHandle.invokeExact are only supported starting with Android O (--min-api 26)
ERROR:/Users/leo/.gradle/caches/modules-2/files-2.1/org.eclipse.jetty/jetty-util/9.4.48.v20220622/7efc06f7ec0ff33d8c219bcc8c7415280c103669/jetty-util-9.4.48.v20220622.jar: D8: com.android.tools.r8.internal.k2: MethodHandle.invoke and MethodHandle.invokeExact are only supported starting with Android O (--min-api 26)
ERROR:/Users/leo/.gradle/caches/modules-2/files-2.1/org.eclipse.jetty/jetty-server/9.4.48.v20220622/b91a0641cda31c93962503b88f783602d2bd8093/jetty-server-9.4.48.v20220622.jar: D8: com.android.tools.r8.internal.k2: MethodHandle.invoke and MethodHandle.invokeExact are only supported starting with Android O (--min-api 26)

> Task :eppo:mergeExtDexDebugAndroidTest FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':eppo:mergeExtDexDebugAndroidTest'.
> Could not resolve all files for configuration ':eppo:debugAndroidTestRuntimeClasspath'.
   > Failed to transform jetty-servlet-9.4.48.v20220622.jar (org.eclipse.jetty:jetty-servlet:9.4.48.v20220622) to match attributes {artifactType=android-dex, asm-transformed-variant=NONE, dexing-enable-desugaring=true, dexing-enable-jacoco-instrumentation=false, dexing-is-debuggable=true, dexing-min-sdk=21, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}.
      > Execution failed for DexingWithClasspathTransform: /Users/leo/.gradle/caches/modules-2/files-2.1/org.eclipse.jetty/jetty-servlet/9.4.48.v20220622/8a9a53e0aad3f194a4cc9940f7e9d5619254bf62/jetty-servlet-9.4.48.v20220622.jar.
         > Error while dexing.
   > Failed to transform jetty-server-9.4.48.v20220622.jar (org.eclipse.jetty:jetty-server:9.4.48.v20220622) to match attributes {artifactType=android-dex, asm-transformed-variant=NONE, dexing-enable-desugaring=true, dexing-enable-jacoco-instrumentation=false, dexing-is-debuggable=true, dexing-min-sdk=21, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}.
      > Execution failed for DexingWithClasspathTransform: /Users/leo/.gradle/caches/modules-2/files-2.1/org.eclipse.jetty/jetty-server/9.4.48.v20220622/b91a0641cda31c93962503b88f783602d2bd8093/jetty-server-9.4.48.v20220622.jar.
         > Error while dexing.
   > Failed to transform jetty-util-9.4.48.v20220622.jar (org.eclipse.jetty:jetty-util:9.4.48.v20220622) to match attributes {artifactType=android-dex, asm-transformed-variant=NONE, dexing-enable-desugaring=true, dexing-enable-jacoco-instrumentation=false, dexing-is-debuggable=true, dexing-min-sdk=21, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}.
      > Execution failed for DexingWithClasspathTransform: /Users/leo/.gradle/caches/modules-2/files-2.1/org.eclipse.jetty/jetty-util/9.4.48.v20220622/7efc06f7ec0ff33d8c219bcc8c7415280c103669/jetty-util-9.4.48.v20220622.jar.
         > Error while dexing.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 4s
38 actionable tasks: 16 executed, 22 up-to-date
```

## description

1. updating example app to min sdk 33 - this seems reasonable as its purpose is to be a demonstration and run tests against.

## test

```
> Task :example:compileDebugAndroidTestJavaWithJavac
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

BUILD SUCCESSFUL in 23s
99 actionable tasks: 55 executed, 44 up-to-date
```