### PR TITLE
migrate package from AndroidManifest.xml to build.gradle (FF-1099)

### DIFF
--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -10,6 +10,8 @@ android {
     compileSdk 33
 
     defaultConfig {
+        namespace "cloud.eppo.android"
+
         gradle.startParameter.taskNames.each {
             if (it.contains("AndroidTest")) {
                 minSdk 33 // required to use wiremock in tests

--- a/eppo/src/androidTest/AndroidManifest.xml
+++ b/eppo/src/androidTest/AndroidManifest.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    package="cloud.eppo.android"
-    >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application android:usesCleartextTraffic="true" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/eppo/src/main/AndroidManifest.xml
+++ b/eppo/src/main/AndroidManifest.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    package="cloud.eppo.android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -7,6 +7,8 @@ android {
 
     defaultConfig {
         applicationId "cloud.eppo.androidexample"
+        namespace "com.geteppo.androidexample"
+
         minSdk 21
         targetSdk 33
         versionCode 1

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.geteppo.androidexample">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
## motiviation

```
➜  android-sdk git:(main) ./gradlew build

> Configure project :eppo
WARNING:Software Components will not be created automatically for Maven publishing from Android Gradle Plugin 8.0. To opt-in to the future behavior, set the Gradle property android.disableAutomaticComponentCreation=true in the `gradle.properties` file or use the new publishing DSL.

> Task :eppo:processReleaseManifest
package="cloud.eppo.android" found in source AndroidManifest.xml: /Users/leo/src/android-sdk/eppo/src/main/AndroidManifest.xml.
Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated.
Please instead set the namespace (or testNamespace) in the module's build.gradle file, as described here: https://developer.android.com/studio/build/configure-app-module#set-namespace
This migration can be done automatically using the AGP Upgrade Assistant, please refer to https://developer.android.com/studio/build/agp-upgrade-assistant for more information.

> Task :eppo:processDebugManifest
package="cloud.eppo.android" found in source AndroidManifest.xml: /Users/leo/src/android-sdk/eppo/src/main/AndroidManifest.xml.
Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated.
Please instead set the namespace (or testNamespace) in the module's build.gradle file, as described here: https://developer.android.com/studio/build/configure-app-module#set-namespace
This migration can be done automatically using the AGP Upgrade Assistant, please refer to https://developer.android.com/studio/build/agp-upgrade-assistant for more information.
```

## description

migrates based on recommendations

## test

✔️ build

```
➜  android-sdk git:(lr/ff-1099/fix-warning-package-android-manifest) ./gradlew build

> Configure project :eppo
WARNING:Software Components will not be created automatically for Maven publishing from Android Gradle Plugin 8.0. To opt-in to the future behavior, set the Gradle property android.disableAutomaticComponentCreation=true in the `gradle.properties` file or use the new publishing DSL.

> Task :eppo:compileDebugJavaWithJavac
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
3 warnings

> Task :eppo:compileReleaseJavaWithJavac
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
3 warnings

> Task :eppo:compileDebugUnitTestJavaWithJavac
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

> Task :eppo:compileReleaseUnitTestJavaWithJavac
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

> Task :eppo:lintReportDebug
Wrote HTML report to file:///Users/leo/src/android-sdk/eppo/build/reports/lint-results-debug.html

> Task :example:compileDebugJavaWithJavac
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

> Task :example:compileReleaseJavaWithJavac
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

> Task :example:lintReportDebug
Wrote HTML report to file:///Users/leo/src/android-sdk/example/build/reports/lint-results-debug.html

BUILD SUCCESSFUL in 6s
154 actionable tasks: 145 executed, 9 up-to-date
```

✔️ test

```
➜  android-sdk git:(lr/ff-1099/fix-warning-package-android-manifest) make test
...
> Task :eppo:eppo:connectedDebugAndroidTest
Starting 2 tests on Pixel_7_API_34(AVD) - 14

BUILD SUCCESSFUL in 18s
1 actionable task: 1 executed
```