### PR TITLE
resolve packagingOptions warning (FF-1100)

### DIFF
--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -47,7 +47,9 @@ android {
         unitTests.returnDefaultValues = true
     }
     packagingOptions {
-        exclude("META-INF/**")
+        resources {
+            excludes += "META-INF/**"
+        }
     }
 }
 


### PR DESCRIPTION
## description

migrates to a new format desired by gradle

<img width="842" alt="Screenshot 2023-10-21 at 9 28 52 AM" src="https://github.com/Eppo-exp/android-sdk/assets/57361/2cde8394-5eb9-4ceb-a681-c4ed4b66a82a">

## test

warning removed

<img width="903" alt="Screenshot 2023-10-21 at 9 28 18 AM" src="https://github.com/Eppo-exp/android-sdk/assets/57361/ccf93902-5f39-4173-b696-a04a35f9725e">
