### PR TITLE
run tests on github actions

### DIFF
--- a/.github/workflows/publish-sdk.yaml
+++ b/.github/workflows/publish-sdk.yaml
@@ -3,9 +3,6 @@ on:
   release:
     types: [published]
 
-env:
-  ANDROID_API_LEVEL: 33
-
 jobs:
   lint-test-sdk:
     runs-on: macos-latest

--- a/.github/workflows/test-sdk.yaml
+++ b/.github/workflows/test-sdk.yaml
@@ -70,9 +70,28 @@ jobs:
       fail-fast: false
       matrix:
         api-level: [ 34 ]
+    services:
+      nginx:
+        image: nginx:latest
+        ports:
+          - 80:80
+        volumes:
+          - ${{ github.workspace }}/test-data:/usr/share/nginx/html:ro
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          repository: github.com/Eppo-exp/sdk-test-data
+          path: test-data
+
+      - name: Test with curl
+        run: curl http://nginx/rac-experiments-v3.json
+
       - name: Check out Android SDK
         uses: actions/checkout@v3
+        with:
+          repository: github.com/Eppo-exp/android-sdk
+          path: android-sdk
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/test-sdk.yaml
+++ b/.github/workflows/test-sdk.yaml
@@ -11,9 +11,6 @@ on:
 jobs:
   test-android-sdk:
     runs-on: macos-latest
-    strategy:
-      matrix:
-        api-level: [ 33 ]
     env:
       ANDROID_API_LEVEL: 33
     steps:
@@ -50,13 +47,13 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-${{ matrix.api-level }}
+          key: avd
 
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: ${{ matrix.api-level }}
+          api-level: 33
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false

--- a/.github/workflows/test-sdk.yaml
+++ b/.github/workflows/test-sdk.yaml
@@ -1,17 +1,45 @@
-name: Test SDK
+name: Android SDK CI
 
 on:
   push:
     branches:
       - main
-  pull_request: #TODO: remove this before merge
-    paths:
-      - '**/*'
+  # Build on all pull requests, regardless of target.
+  pull_request:
 
 jobs:
-  test-android-sdk:
-    runs-on: macos-latest
+  build:
     strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Build with Gradle
+        run: ./gradlew build
+
+  unit-tests:
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Build with Gradle
+        run: make unit-test
+
+  instrumentation-tests:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    strategy:
+      # Allow tests to continue on other devices if they fail on one device.
+      fail-fast: false
       matrix:
         api-level: [ 33 ]
     steps:
@@ -73,4 +101,4 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: ./gradlew connectedCheck
+          script: make instrumentation-test

--- a/.github/workflows/test-sdk.yaml
+++ b/.github/workflows/test-sdk.yaml
@@ -71,6 +71,12 @@ jobs:
       matrix:
         api-level: [ 34 ]
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          repository: github.com/Eppo-exp/sdk-test-data
+          path: test-data
+
       # the macos github action images have docker installed but the daemon is not
       # automatically started. this means we cannot use services since those run
       # before the steps.
@@ -80,12 +86,6 @@ jobs:
       - name: Start nginx container
         run: |
           docker run -d -p 8080:80 -v ${{ github.workspace }}/test-data:/usr/share/nginx/html:ro nginx:latest
-
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          repository: github.com/Eppo-exp/sdk-test-data
-          path: test-data
 
       - name: Test with curl
         run: curl http://localhost:8080/rac-experiments-v3.json

--- a/.github/workflows/test-sdk.yaml
+++ b/.github/workflows/test-sdk.yaml
@@ -111,7 +111,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          profile: Pixel 7
+          profile: pixel_7
           target: google_apis
           arch: x86_64
           force-avd-creation: false
@@ -123,7 +123,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          profile: Pixel 7
+          profile: pixel_7
           target: google_apis
           arch: x86_64
           force-avd-creation: false

--- a/.github/workflows/test-sdk.yaml
+++ b/.github/workflows/test-sdk.yaml
@@ -74,8 +74,8 @@ jobs:
       # the macos github action images have docker installed but the daemon is not
       # automatically started. this means we cannot use services since those run
       # before the steps.
-      - name: Start Docker
-        run: open --background -a Docker && while ! docker info > /dev/null 2>&1; do sleep 1; done
+      - name: Set up Docker
+        uses: crazy-max/ghaction-setup-docker@v1
 
       - name: Start nginx container
         run: |

--- a/.github/workflows/test-sdk.yaml
+++ b/.github/workflows/test-sdk.yaml
@@ -69,7 +69,7 @@ jobs:
       # Allow tests to continue on other devices if they fail on one device.
       fail-fast: false
       matrix:
-        api-level: [ 33 ]
+        api-level: [ 34 ]
     steps:
       - name: Check out Android SDK
         uses: actions/checkout@v3
@@ -111,7 +111,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          profile: Nexus 6
+          profile: Pixel 7
           target: google_apis
           arch: x86_64
           force-avd-creation: false
@@ -123,7 +123,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          profile: Nexus 6
+          profile: Pixel 7
           target: google_apis
           arch: x86_64
           force-avd-creation: false

--- a/.github/workflows/test-sdk.yaml
+++ b/.github/workflows/test-sdk.yaml
@@ -122,8 +122,6 @@ jobs:
       - name: run tests
         uses: reactivecircus/android-emulator-runner@v2
         continue-on-error: true # IMPORTANT: allow pipeline to continue to Android Test Report step
-        env:
-          WIREMOCK_BASE_URL: 10.0.2.2
         with:
           api-level: ${{ matrix.api-level }}
           profile: 29 # pixel 7

--- a/.github/workflows/test-sdk.yaml
+++ b/.github/workflows/test-sdk.yaml
@@ -121,6 +121,7 @@ jobs:
 
       - name: run tests
         uses: reactivecircus/android-emulator-runner@v2
+        continue-on-error: true # IMPORTANT: allow pipeline to continue to Android Test Report step
         with:
           api-level: ${{ matrix.api-level }}
           profile: 29 # pixel 7
@@ -129,4 +130,20 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: make instrumentation-test
+          script: |
+            adb logcat -c                             # clear logs
+            touch app/emulator.log                    # create log file
+            chmod 777 app/emulator.log                # allow writing to log file
+            adb logcat >> app/emulator.log &          # pipe all logcat messages into log file as a background process
+            make instrumentation-test                 # here run our tests   
+
+      - name: Upload Failing Test Report Log
+        if: steps.testing.outcome != 'success'        # upload the generated log on failure of the tests job
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs
+          path: app/emulator.log # path to where the log is
+
+      - name: Raise error on test fail # set a red tick on the workflow run if the tests failed
+        if: steps.testing.outcome != 'success'
+        run: exit 1

--- a/.github/workflows/test-sdk.yaml
+++ b/.github/workflows/test-sdk.yaml
@@ -111,7 +111,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          profile: pixel_7
+          profile: 29 # pixel 7
           target: google_apis
           arch: x86_64
           force-avd-creation: false
@@ -123,7 +123,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          profile: pixel_7
+          profile: 29 # pixel 7
           target: google_apis
           arch: x86_64
           force-avd-creation: false

--- a/.github/workflows/test-sdk.yaml
+++ b/.github/workflows/test-sdk.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          repository: github.com/Eppo-exp/sdk-test-data
+          repository: Eppo-exp/sdk-test-data
           path: test-data
 
       # the macos github action images have docker installed but the daemon is not
@@ -93,7 +93,7 @@ jobs:
       - name: Check out Android SDK
         uses: actions/checkout@v3
         with:
-          repository: github.com/Eppo-exp/android-sdk
+          repository: Eppo-exp/android-sdk
           path: android-sdk
 
       - name: Set up JDK 11

--- a/.github/workflows/test-sdk.yaml
+++ b/.github/workflows/test-sdk.yaml
@@ -27,10 +27,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: set up JDK 11
-        uses: actions/setup-java@v1
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: '11'
+          distribution: 'adopt'
+
+      - name: Restore gradle.properties
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }} #TODO: populate
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }} #TODO: populate
+        shell: bash
+        run: |
+          mkdir -p ~/.gradle/
+          echo "GRADLE_USER_HOME=${HOME}/.gradle" >> $GITHUB_ENV
+          echo "MAVEN_USERNAME=${MAVEN_USERNAME}" > ~/.gradle/gradle.properties
+          echo "MAVEN_PASSWORD=${MAVEN_PASSWORD}" >> ~/.gradle/gradle.properties
+
       - name: Build with Gradle
         run: make unit-test
 

--- a/.github/workflows/test-sdk.yaml
+++ b/.github/workflows/test-sdk.yaml
@@ -14,10 +14,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: set up JDK 11
-        uses: actions/setup-java@v1
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: '11'
+          distribution: 'adopt'
+
+      - name: Restore gradle.properties
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+        shell: bash
+        run: |
+          mkdir -p ~/.gradle/
+          echo "GRADLE_USER_HOME=${HOME}/.gradle" >> $GITHUB_ENV
+          echo "MAVEN_USERNAME=${MAVEN_USERNAME}" > ~/.gradle/gradle.properties
+          echo "MAVEN_PASSWORD=${MAVEN_PASSWORD}" >> ~/.gradle/gradle.properties
+
       - name: Build with Gradle
         run: ./gradlew build
 

--- a/.github/workflows/test-sdk.yaml
+++ b/.github/workflows/test-sdk.yaml
@@ -11,21 +11,22 @@ on:
 jobs:
   test-android-sdk:
     runs-on: macos-latest
-    env:
-      ANDROID_API_LEVEL: 30
+    strategy:
+      matrix:
+        api-level: [ 33 ]
     steps:
       - name: Check out Android SDK
         uses: actions/checkout@v3
-        with:
-          repository: 'Eppo-exp/android-sdk'
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: 'adopt'
+
       - name: 'Set up GCP SDK'
         uses: 'google-github-actions/setup-gcloud@v0'
+
       - name: Restore gradle.properties
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }} #TODO: populate
@@ -47,27 +48,29 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd
+          key: avd-${{ matrix.api-level }}
 
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 30
+          api-level: ${{ matrix.api-level }}
+          profile: Nexus 6
           target: google_apis
-          arch: x86
+          arch: x86_64
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
 
-      - name: Run tests on emulator
-        uses: ReactiveCircus/android-emulator-runner@v2
+      - name: run tests
+        uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 30
+          api-level: ${{ matrix.api-level }}
+          profile: Nexus 6
           target: google_apis
-          arch: x86
+          arch: x86_64
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: make test
+          script: ./gradlew connectedCheck

--- a/.github/workflows/test-sdk.yaml
+++ b/.github/workflows/test-sdk.yaml
@@ -79,7 +79,7 @@ jobs:
           - ${{ github.workspace }}/test-data:/usr/share/nginx/html:ro
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: github.com/Eppo-exp/sdk-test-data
           path: test-data

--- a/.github/workflows/test-sdk.yaml
+++ b/.github/workflows/test-sdk.yaml
@@ -70,14 +70,17 @@ jobs:
       fail-fast: false
       matrix:
         api-level: [ 34 ]
-    services:
-      nginx:
-        image: nginx:latest
-        ports:
-          - 80:80
-        volumes:
-          - ${{ github.workspace }}/test-data:/usr/share/nginx/html:ro
     steps:
+      # the macos github action images have docker installed but the daemon is not
+      # automatically started. this means we cannot use services since those run
+      # before the steps.
+      - name: Start Docker
+        run: open --background -a Docker && while ! docker info > /dev/null 2>&1; do sleep 1; done
+
+      - name: Start nginx container
+        run: |
+          docker run -d -p 8080:80 -v ${{ github.workspace }}/test-data:/usr/share/nginx/html:ro nginx:latest
+
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
@@ -85,7 +88,7 @@ jobs:
           path: test-data
 
       - name: Test with curl
-        run: curl http://nginx/rac-experiments-v3.json
+        run: curl http://localhost:8080/rac-experiments-v3.json
 
       - name: Check out Android SDK
         uses: actions/checkout@v3

--- a/.github/workflows/test-sdk.yaml
+++ b/.github/workflows/test-sdk.yaml
@@ -1,0 +1,74 @@
+name: Test SDK
+
+on:
+  push:
+    branches:
+      - main
+  pull_request: #TODO: remove this before merge
+    paths:
+      - '**/*'
+
+jobs:
+  test-android-sdk:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        api-level: [ 33 ]
+    env:
+      ANDROID_API_LEVEL: 33
+    steps:
+      - name: Check out Android SDK
+        uses: actions/checkout@v3
+        with:
+          repository: 'Eppo-exp/android-sdk'
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: 'Set up GCP SDK'
+        uses: 'google-github-actions/setup-gcloud@v0'
+      - name: Restore gradle.properties
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }} #TODO: populate
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }} #TODO: populate
+        shell: bash
+        run: |
+          mkdir -p ~/.gradle/
+          echo "GRADLE_USER_HOME=${HOME}/.gradle" >> $GITHUB_ENV
+          echo "MAVEN_USERNAME=${MAVEN_USERNAME}" > ~/.gradle/gradle.properties
+          echo "MAVEN_PASSWORD=${MAVEN_PASSWORD}" >> ~/.gradle/gradle.properties
+
+      - name: Gradle cache
+        uses: gradle/gradle-build-action@v2
+
+      - name: AVD cache
+        uses: actions/cache@v3
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}
+
+      - name: create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
+      - name: Run tests on emulator
+        uses: ReactiveCircus/android-emulator-runner@v2
+        with:
+          api-level: 33
+          target: google_apis
+          arch: x86_64
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: make test

--- a/.github/workflows/test-sdk.yaml
+++ b/.github/workflows/test-sdk.yaml
@@ -135,7 +135,7 @@ jobs:
             mkdir -p app/                                       # create directory
             touch app/emulator.log                              # create log file
             chmod 777 app/emulator.log                          # allow writing to log file
-            adb logcat cloud.eppo:D *:S >> app/emulator.log &   # pipe all logcat messages into log file as a background process
+            adb logcat EppoSDK:D "*:S" >> app/emulator.log &   # pipe all logcat messages into log file as a background process
             make instrumentation-test                           # run our tests   
 
       - name: Upload Failing Test Report Log

--- a/.github/workflows/test-sdk.yaml
+++ b/.github/workflows/test-sdk.yaml
@@ -131,12 +131,12 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: |
-            adb logcat -c                             # clear logs
-            mkdir -p app/                             # create directory
-            touch app/emulator.log                    # create log file
-            chmod 777 app/emulator.log                # allow writing to log file
-            adb logcat >> app/emulator.log &          # pipe all logcat messages into log file as a background process
-            make instrumentation-test                 # here run our tests   
+            adb logcat -c                                       # clear logs
+            mkdir -p app/                                       # create directory
+            touch app/emulator.log                              # create log file
+            chmod 777 app/emulator.log                          # allow writing to log file
+            adb logcat cloud.eppo:D *:S >> app/emulator.log &   # pipe all logcat messages into log file as a background process
+            make instrumentation-test                           # run our tests   
 
       - name: Upload Failing Test Report Log
         if: steps.testing.outcome != 'success'        # upload the generated log on failure of the tests job

--- a/.github/workflows/test-sdk.yaml
+++ b/.github/workflows/test-sdk.yaml
@@ -54,6 +54,8 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 33
+          target: google_apis
+          arch: x86
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
@@ -64,7 +66,7 @@ jobs:
         with:
           api-level: 33
           target: google_apis
-          arch: x86_64
+          arch: x86
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true

--- a/.github/workflows/test-sdk.yaml
+++ b/.github/workflows/test-sdk.yaml
@@ -122,6 +122,8 @@ jobs:
       - name: run tests
         uses: reactivecircus/android-emulator-runner@v2
         continue-on-error: true # IMPORTANT: allow pipeline to continue to Android Test Report step
+        env:
+          WIREMOCK_BASE_URL: 10.0.2.2
         with:
           api-level: ${{ matrix.api-level }}
           profile: 29 # pixel 7

--- a/.github/workflows/test-sdk.yaml
+++ b/.github/workflows/test-sdk.yaml
@@ -12,7 +12,7 @@ jobs:
   test-android-sdk:
     runs-on: macos-latest
     env:
-      ANDROID_API_LEVEL: 33
+      ANDROID_API_LEVEL: 30
     steps:
       - name: Check out Android SDK
         uses: actions/checkout@v3
@@ -53,7 +53,7 @@ jobs:
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 33
+          api-level: 30
           target: google_apis
           arch: x86
           force-avd-creation: false
@@ -64,7 +64,7 @@ jobs:
       - name: Run tests on emulator
         uses: ReactiveCircus/android-emulator-runner@v2
         with:
-          api-level: 33
+          api-level: 30
           target: google_apis
           arch: x86
           force-avd-creation: false

--- a/.github/workflows/test-sdk.yaml
+++ b/.github/workflows/test-sdk.yaml
@@ -132,6 +132,7 @@ jobs:
           disable-animations: true
           script: |
             adb logcat -c                             # clear logs
+            mkdir -p app/                             # create directory
             touch app/emulator.log                    # create log file
             chmod 777 app/emulator.log                # allow writing to log file
             adb logcat >> app/emulator.log &          # pipe all logcat messages into log file as a background process

--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,6 @@ test-data:
 ## test
 .PHONY: test
 test: test-data
-	# $(INFO)Uninstalling old version of test app(END)
-	adb uninstall cloud.eppo.android.test
 	# $(INFO)Running tests(END)
 	./gradlew runEppoTests
 

--- a/Makefile
+++ b/Makefile
@@ -42,11 +42,15 @@ test-data:
 	cp -r ${gitDataDir}/assignment-v2 ${testDataDir}
 	rm -rf ${tempDir}
 
-## test
-.PHONY: test
-test: test-data
-	# $(INFO)Running tests(END)
-	./gradlew runEppoTests
+## instrumentation-test
+.PHONY: instrumentation-test
+instrumentation-test: test-data
+	./gradlew connectedCheck
+
+## unit-test
+.PHONY: unit-test
+unit-test:
+	./gradlew test
 
 check-maven-credentials-and-publish:
 	# $(INFO)Checking required gradle configuration(END)

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.3.1' apply false
-    id 'com.android.library' version '7.3.1' apply false
+    id 'com.android.application' version '7.4.2' apply false
+    id 'com.android.library' version '7.4.2' apply false
 }
 
 task clean(type: Delete) {

--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -120,10 +120,3 @@ publishing {
         }
     }
 }
-
-task runEppoTests(type: GradleBuild) {
-    tasks = [
-        ':eppo:testDebugUnitTest',
-        ':eppo:connectedDebugAndroidTest'
-    ]
-}

--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -11,7 +11,7 @@ android {
 
     defaultConfig {
         gradle.startParameter.taskNames.each {
-            if (it.contains("AndroidTest")) {
+            if (it.contains("AndroidTest") || it.contains('connectedCheck')) {
                 minSdk 33 // required to use wiremock in tests
             } else {
                 minSdk 21

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -185,6 +185,21 @@ public class EppoClientTest {
         runTestCases();
     }
 
+//    @Test
+//    public void testCachedAssignments() {
+//        try {
+//            initClient(HOST, false, true); // ensure cache is populated
+//            initClient(INVALID_HOST, false, false); // invalid port to force to use cache
+//
+//            // wait for a bit since file is loaded asynchronously
+//            System.out.println("Sleeping for a bit to wait for cache population to complete");
+//            Thread.sleep(1000);
+//        } catch (Exception e) {
+//            fail();
+//        }
+//        runTestCases();
+//    }
+
     private void runTestCases() {
         try {
             int testsRan = 0;
@@ -197,21 +212,6 @@ public class EppoClientTest {
         } catch (Exception e) {
             fail();
         }
-    }
-
-    @Test
-    public void testCachedAssignments() {
-        try {
-            initClient(HOST, false, true); // ensure cache is populated
-            initClient(INVALID_HOST, false, false); // invalid port to force to use cache
-
-            // wait for a bit since file is loaded asynchronously
-            System.out.println("Sleeping for a bit to wait for cache population to complete");
-            Thread.sleep(1000);
-        } catch (Exception e) {
-            fail();
-        }
-        runTestCases();
     }
 
     private int runTestCaseFileStream(InputStream testCaseStream) throws IOException {

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -20,19 +20,16 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
-
 import org.apache.commons.io.Charsets;
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Type;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -43,7 +40,7 @@ import cloud.eppo.android.dto.adapters.EppoValueAdapter;
 
 public class EppoClientTest {
     private static final int TEST_PORT = 4001;
-    private String HOST = "10.0.2.2:" + TEST_PORT; //Optional.ofNullable(System.getenv("WIREMOCK_BASE_URL")).orElse("http://localhost:") + TEST_PORT;
+    private String HOST = "http://127.0.0.1:" + 4001;
 
     private WireMockServer mockServer;
     private Gson gson = new GsonBuilder()

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -40,7 +40,7 @@ import cloud.eppo.android.dto.adapters.EppoValueAdapter;
 
 public class EppoClientTest {
     private static final int TEST_PORT = 4001;
-    private String HOST = "http://127.0.0.1:" + 4001;
+    private String HOST = "http://10.0.2.2:" + 4001;
 
     private WireMockServer mockServer;
     private Gson gson = new GsonBuilder()

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -40,7 +40,7 @@ import cloud.eppo.android.dto.adapters.EppoValueAdapter;
 
 public class EppoClientTest {
     private static final int TEST_PORT = 8080;
-    private String HOST = "http://10.0.2.2:" + TEST_PORT;
+    private String HOST = "http://localhost:" + TEST_PORT;
 
     private WireMockServer mockServer;
     private Gson gson = new GsonBuilder()

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -132,6 +132,7 @@ public class EppoClientTest {
             deleteCacheFiles();
         }
 
+        Log.d(LoggingTag, "initializing client with host: " + host);
         new EppoClient.Builder()
                 .application(ApplicationProvider.getApplicationContext())
                 .apiKey("mock-api-key")
@@ -179,7 +180,7 @@ public class EppoClientTest {
         this.mockServer.start();
 
         this.HOST = this.mockServer.baseUrl(); // this includes the port
-        Log.i(LoggingTag, "host:" + this.HOST);
+        Log.i(LoggingTag, "setupMockRacServer host:" + this.HOST);
 
         String racResponseJson = getMockRandomizedAssignmentResponse();
         this.mockServer.stubFor(WireMock.get(WireMock.urlMatching(".*randomized_assignment.*"))

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -7,6 +7,8 @@ import static org.junit.Assert.fail;
 import static cloud.eppo.android.ConfigCacheFile.CACHE_FILE_NAME;
 
 import android.content.res.AssetManager;
+import android.util.Log;
+
 import androidx.test.core.app.ApplicationProvider;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
@@ -40,8 +42,7 @@ import cloud.eppo.android.dto.adapters.EppoValueAdapter;
 public class EppoClientTest {
     private static final String TAG = EppoClientTest.class.getSimpleName();
     private static final int TEST_PORT = 4001;
-    private static final String HOST = "http://localhost:" + TEST_PORT;
-    private static final String INVALID_HOST = "http://localhost:" + (TEST_PORT + 1);
+    private String HOST;
     private WireMockServer mockServer;
     private Gson gson = new GsonBuilder()
             .registerTypeAdapter(EppoValue.class, new EppoValueAdapter())
@@ -144,6 +145,7 @@ public class EppoClientTest {
                     @Override
                     public void onError(String errorMessage) {
                         if (throwOnCallackError) {
+                            Log.e(TAG, "initClient onError: " + errorMessage);
                             throw new RuntimeException("Unable to initialize");
                         }
                         lock.countDown();
@@ -175,6 +177,10 @@ public class EppoClientTest {
     private void setupMockRacServer() {
         this.mockServer = new WireMockServer(TEST_PORT);
         this.mockServer.start();
+
+        this.HOST = this.mockServer.baseUrl(); // this includes the port
+        Log.i(TAG, "host:" + this.HOST);
+
         String racResponseJson = getMockRandomizedAssignmentResponse();
         this.mockServer.stubFor(WireMock.get(WireMock.urlMatching(".*randomized_assignment.*"))
                 .willReturn(WireMock.okJson(racResponseJson)));

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -43,7 +43,7 @@ import cloud.eppo.android.dto.adapters.EppoValueAdapter;
 
 public class EppoClientTest {
     private static final int TEST_PORT = 4001;
-    private String HOST = Optional.ofNullable(System.getenv("WIREMOCK_BASE_URL")).orElse("http://localhost:") + TEST_PORT;
+    private String HOST = "10.0.2.2:" + TEST_PORT; //Optional.ofNullable(System.getenv("WIREMOCK_BASE_URL")).orElse("http://localhost:") + TEST_PORT;
 
     private WireMockServer mockServer;
     private Gson gson = new GsonBuilder()

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import static cloud.eppo.android.ConfigCacheFile.CACHE_FILE_NAME;
+import static cloud.eppo.android.Constants.LoggingTag;
 
 import android.content.res.AssetManager;
 import android.util.Log;
@@ -40,7 +41,6 @@ import cloud.eppo.android.dto.SubjectAttributes;
 import cloud.eppo.android.dto.adapters.EppoValueAdapter;
 
 public class EppoClientTest {
-    private static final String TAG = EppoClientTest.class.getSimpleName();
     private static final int TEST_PORT = 4001;
     private String HOST;
     private WireMockServer mockServer;
@@ -145,7 +145,7 @@ public class EppoClientTest {
                     @Override
                     public void onError(String errorMessage) {
                         if (throwOnCallackError) {
-                            Log.e(TAG, "initClient onError: " + errorMessage);
+                            Log.e(LoggingTag, "initClient onError: " + errorMessage);
                             throw new RuntimeException("Unable to initialize");
                         }
                         lock.countDown();
@@ -179,7 +179,7 @@ public class EppoClientTest {
         this.mockServer.start();
 
         this.HOST = this.mockServer.baseUrl(); // this includes the port
-        Log.i(TAG, "host:" + this.HOST);
+        Log.i(LoggingTag, "host:" + this.HOST);
 
         String racResponseJson = getMockRandomizedAssignmentResponse();
         this.mockServer.stubFor(WireMock.get(WireMock.urlMatching(".*randomized_assignment.*"))

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Type;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -42,7 +43,8 @@ import cloud.eppo.android.dto.adapters.EppoValueAdapter;
 
 public class EppoClientTest {
     private static final int TEST_PORT = 4001;
-    private String HOST;
+    private String HOST = Optional.ofNullable(System.getenv("WIREMOCK_BASE_URL")).orElse("http://localhost:") + TEST_PORT;
+
     private WireMockServer mockServer;
     private Gson gson = new GsonBuilder()
             .registerTypeAdapter(EppoValue.class, new EppoValueAdapter())
@@ -178,9 +180,6 @@ public class EppoClientTest {
     private void setupMockRacServer() {
         this.mockServer = new WireMockServer(TEST_PORT);
         this.mockServer.start();
-
-        this.HOST = this.mockServer.baseUrl(); // this includes the port
-        Log.i(LoggingTag, "setupMockRacServer host:" + this.HOST);
 
         String racResponseJson = getMockRandomizedAssignmentResponse();
         this.mockServer.stubFor(WireMock.get(WireMock.urlMatching(".*randomized_assignment.*"))

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -39,8 +39,8 @@ import cloud.eppo.android.dto.SubjectAttributes;
 import cloud.eppo.android.dto.adapters.EppoValueAdapter;
 
 public class EppoClientTest {
-    private static final int TEST_PORT = 4001;
-    private String HOST = "http://10.0.2.2:" + 4001;
+    private static final int TEST_PORT = 8080;
+    private String HOST = "http://10.0.2.2:" + TEST_PORT;
 
     private WireMockServer mockServer;
     private Gson gson = new GsonBuilder()

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationRequestor.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationRequestor.java
@@ -1,5 +1,7 @@
 package cloud.eppo.android;
 
+import static cloud.eppo.android.Constants.LoggingTag;
+
 import android.util.Log;
 
 import com.google.gson.JsonIOException;
@@ -10,7 +12,6 @@ import java.io.Reader;
 import cloud.eppo.android.dto.FlagConfig;
 
 public class ConfigurationRequestor {
-    private static final String TAG = ConfigurationRequestor.class.getCanonicalName();
 
     private EppoHttpClient client;
     private ConfigurationStore configurationStore;
@@ -29,7 +30,7 @@ public class ConfigurationRequestor {
                 try {
                     configurationStore.setFlags(response);
                 } catch (JsonSyntaxException | JsonIOException e) {
-                    Log.e(TAG, "Error loading configuration response", e);
+                    Log.e(LoggingTag, "Error loading configuration response", e);
                     if (callback != null && !usedCache) {
                         callback.onError("Unable to load configuration from network");
                     }
@@ -43,7 +44,7 @@ public class ConfigurationRequestor {
 
             @Override
             public void onFailure(String errorMessage) {
-                Log.e(TAG, errorMessage);
+                Log.e(LoggingTag, errorMessage);
                 if (callback != null && !usedCache) {
                     callback.onError(errorMessage);
                 }

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
@@ -1,5 +1,7 @@
 package cloud.eppo.android;
 
+import static cloud.eppo.android.Constants.LoggingTag;
+
 import android.app.Application;
 import android.content.SharedPreferences;
 import android.os.AsyncTask;
@@ -22,8 +24,6 @@ import cloud.eppo.android.dto.adapters.EppoValueAdapter;
 import cloud.eppo.android.util.Utils;
 
 public class ConfigurationStore {
-
-    private static final String TAG = ConfigurationStore.class.getSimpleName();
 
     private final Gson gson = new GsonBuilder()
             .registerTypeAdapter(EppoValue.class, new EppoValueAdapter())
@@ -54,7 +54,7 @@ public class ConfigurationStore {
                     flags = configResponse.getFlags();
                 }
             } catch (Exception e) {
-                Log.e(TAG, "Error loading from local cache", e);
+                Log.e(LoggingTag, "Error loading from local cache", e);
                 cacheFile.delete();
 
                 if (callback != null) {
@@ -117,7 +117,7 @@ public class ConfigurationStore {
                     writer.close();
                 }
             } catch (Exception e) {
-                Log.e(TAG, "Unable to cache config to file", e);
+                Log.e(LoggingTag, "Unable to cache config to file", e);
             }
         });
     }
@@ -126,7 +126,7 @@ public class ConfigurationStore {
         try {
             return gson.fromJson(sharedPrefs.getString(hashedFlagKey, null), FlagConfig.class);
         } catch (Exception e) {
-            Log.e(TAG, "Unable to load flag from prefs", e);
+            Log.e(LoggingTag, "Unable to load flag from prefs", e);
         }
         return null;
     }

--- a/eppo/src/main/java/cloud/eppo/android/Constants.java
+++ b/eppo/src/main/java/cloud/eppo/android/Constants.java
@@ -1,0 +1,5 @@
+package cloud.eppo.android;
+
+public class Constants {
+    public static final String LoggingTag = "cloud.eppo";
+}

--- a/eppo/src/main/java/cloud/eppo/android/Constants.java
+++ b/eppo/src/main/java/cloud/eppo/android/Constants.java
@@ -1,5 +1,5 @@
 package cloud.eppo.android;
 
 public class Constants {
-    public static final String LoggingTag = "cloud.eppo";
+    public static final String LoggingTag = "EppoSDK";
 }

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -1,5 +1,6 @@
 package cloud.eppo.android;
 
+import static cloud.eppo.android.Constants.LoggingTag;
 import static cloud.eppo.android.util.Utils.validateNotEmptyOrNull;
 
 import android.app.ActivityManager;
@@ -26,7 +27,6 @@ import cloud.eppo.android.logging.AssignmentLogger;
 import cloud.eppo.android.util.Utils;
 
 public class EppoClient {
-    private static final String TAG = EppoClient.class.getCanonicalName();
     private static final String DEFAULT_HOST = "https://fscdn.eppo.cloud";
 
     private final ConfigurationRequestor requestor;
@@ -103,7 +103,7 @@ public class EppoClient {
 
         FlagConfig flag = requestor.getConfiguration(flagKey);
         if (flag == null) {
-            Log.w(TAG, "no configuration found for key: " + flagKey);
+            Log.w(LoggingTag, "no configuration found for key: " + flagKey);
             return null;
         }
 
@@ -113,20 +113,20 @@ public class EppoClient {
         }
 
         if (!flag.isEnabled()) {
-            Log.i(TAG, "no assigned variation because the experiment or feature flag is disabled: " + flagKey);
+            Log.i(LoggingTag, "no assigned variation because the experiment or feature flag is disabled: " + flagKey);
             return null;
         }
 
         TargetingRule rule = RuleEvaluator.findMatchingRule(subjectAttributes, flag.getRules());
         if (rule == null) {
-            Log.i(TAG, "no assigned variation. The subject attributes did not match any targeting rules");
+            Log.i(LoggingTag, "no assigned variation. The subject attributes did not match any targeting rules");
             return null;
         }
 
         String allocationKey = rule.getAllocationKey();
         Allocation allocation = flag.getAllocations().get(allocationKey);
         if (!isInExperimentSample(subjectKey, flagKey, flag.getSubjectShards(), allocation.getPercentExposure())) {
-            Log.i(TAG, "no assigned variation. The subject is not part of the sample population");
+            Log.i(LoggingTag, "no assigned variation. The subject is not part of the sample population");
             return null;
         }
 

--- a/eppo/src/main/java/cloud/eppo/android/EppoHttpClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoHttpClient.java
@@ -1,5 +1,7 @@
 package cloud.eppo.android;
 
+import static cloud.eppo.android.Constants.LoggingTag;
+
 import android.util.Log;
 
 import java.io.IOException;
@@ -37,6 +39,7 @@ public class EppoHttpClient {
                 .build();
 
         Request request = new Request.Builder().url(httpUrl).build();
+        Log.d(LoggingTag, "Attempting to request from baseUrl: " + baseUrl);
         client.newCall(request).enqueue(new Callback() {
             @Override
             public void onResponse(Call call, Response response) {
@@ -49,9 +52,9 @@ public class EppoHttpClient {
                             break;
                         default:
                             if (BuildConfig.DEBUG) {
-                                Log.e(EppoHttpClient.class.getCanonicalName(), "Fetch failed with status code: " + response.code());
+                                Log.e(LoggingTag, "Fetch failed with status code: " + response.code());
                             }
-                            callback.onFailure("Unable to fetch from URL");
+                            callback.onFailure("Unable to fetch from URL with baseUrl: " + baseUrl);
                     }
                 }
                 response.close();

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -7,7 +7,7 @@ android {
 
     defaultConfig {
         applicationId "cloud.eppo.androidexample"
-        minSdk 21
+        minSdk 33
         targetSdk 33
         versionCode 1
         versionName "1.0"

--- a/example/src/main/java/cloud/eppo/androidexample/EppoApplication.java
+++ b/example/src/main/java/cloud/eppo/androidexample/EppoApplication.java
@@ -1,5 +1,7 @@
 package cloud.eppo.androidexample;
 
+import static cloud.eppo.android.Constants.LoggingTag;
+
 import android.app.Application;
 import android.util.Log;
 
@@ -7,7 +9,6 @@ import cloud.eppo.android.EppoClient;
 import cloud.eppo.android.InitializationCallback;
 
 public class EppoApplication extends Application {
-    private static final String TAG = EppoApplication.class.getSimpleName();
     private static final String API_KEY = "REPLACE WITH YOUR API KEY";
 
     @Override
@@ -22,7 +23,7 @@ public class EppoApplication extends Application {
             .callback(new InitializationCallback() {
                 @Override
                 public void onCompleted() {
-                    Log.d(TAG, "Eppo SDK initialized");
+                    Log.d(LoggingTag, "Eppo SDK initialized");
                 }
 
                 @Override

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Sep 06 11:52:39 CEST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## current status

**success**

_local_

* unit tests pass
* instrumentation tests pass

using pixel 7

```
➜  android-sdk git:(lr/poc/github-actions-ci) make instrumentation-test
...
> Configure project :eppo
WARNING:Software Components will not be created automatically for Maven publishing from Android Gradle Plugin 8.0. To opt-in to the future behavior, set the Gradle property android.disableAutomaticComponentCreation=true in the `gradle.properties` file or use the new publishing DSL.

> Task :eppo:connectedDebugAndroidTest
Starting 2 tests on Pixel_7_API_34(AVD) - 14

BUILD SUCCESSFUL in 11s
99 actionable tasks: 2 executed, 97 up-to-date
```

_cloud_

* matrix test targets api sdk 33
* emulator starts in 6 minutes from cache
* dex exception does not happen
* logs from android devices are uploaded as a github artifact and available for developers to download

<img width="1148" alt="Screenshot 2023-10-22 at 3 36 42 PM" src="https://github.com/Eppo-exp/android-sdk/assets/57361/9eb178ec-e4cb-44ae-971f-96e8e6ee7ef0">

**needs work**

👉  Back to the same milestone Agam was with his attempt (https://github.com/Eppo-exp/android-sdk/pull/22/files) - I suspect the wiremock server is not setup in the same way as on local

* connect test fails

```
> Task :eppo:connectedDebugAndroidTest
Starting 2 tests on test(AVD) - 13

cloud.eppo.android.EppoClientTest > testCachedAssignments[test(AVD) - 13] FAILED 
	java.lang.AssertionError: expected:<[null, null, control, null, null, green, null, null, red, green, null, null, control, green, green, null, null, control, null, red, null, red, null, null, null, null, null, null, null, null, control, null, null, null, null, null, null, control, green, green, null, null, null, control, green, control, control, control, null, control, green, null, control, control, green, null, null, green, control, null, control, null, green, green, red, null, null, null, null, control, null, control, null, null, red, null, null, null, control, null, control, red, control, control, null, null, green, red, green, null, null, green, red, null, green, null, null, red, null, green, control, red, null, red, null, red, red, null, null, control, null, null, control, null, red, red, null, control, null, green, green, null, green, control, green, null, null, null, red, null, green, null, control, null, null, null, null, null, control, control, green, null, null, green, null, control, null, red, null, null, null, null, control, red, null, green, null, null, null, green, green, null, null, null, null, null, null, null, null, control, null, control, null, red, null, null, null, red, red, null, green, null, null, red, green, null, null, control, null, null, null, red, null, control, green, null, green, red, null, null, null, green, null, red, null, null, null, null, null, green, green, null, null, green, green, null, red, control, red, null, null, null, control, green, null, null, red, null, null, green, null, null, null, red, null, null, null, null, green, null, red, null, red, red, null, null, null, red, null, green, null, null, null, green, green, null, red, red, null, null, null, green, red, null, control, control, control, red, green, null, control, green, null, null, null, control, null, null, control, null, control, green, null, null, green, null, red, null, null, green, null, control, red, null, null, green, red, control, control, null, null, red, green, null, null, null, control, control, red, green, null, null, null, null, red, red, control, null, control, null, green, null, red, red, null, green, control, control, null, null, null, red, null, null, green, null, null, null, null, null, null, null, null, null, red, control, null, null, null, red, null, null, red, red, green, null, null, null, control, green, red, control, red, control, null, green, null, green, null, red, red, control, null, null, red, green, null, null, red, null, control, null, control, red, null, null, red, null, green, green, control, green, control, control, null, control, green, null, null, null, control, control, null, null, green, green, null, green, green, null, null, red, null, green, null, green, green, red, null, null, green, null, control, red, null, null, control, red, null, null, green, control, control, null, red, null, control, null, null, null, red, null, null, green, null, null, green, red, null, control, green, null, null, green, null, null, null, red, null, green, null, null, red, green, null, control, red, control, null, null, green, red, red, green, green, null, control, red, control, null, null, red, null, null, null, null, red, green, green, null, red, green, red, null, green, control, control, null, control, null, null, red, null, null, null, null, control, control, null, null, green, control, red, red, control, null, red, green, null, red, null, red, null, red, null, green, null, null, red, red, null, null, null, null, green, red, red, null, red, null, null, green, null, null, null, null, green, green, red, null, null, null, red, null, null, null, control, control, null, null, null, null, red, green, null, green, null, green, null, red, control, null, control, red, green, null, null, null, control, green, null, null, null, null, null, green, null, null, red, null, red, null, green, null, green, null, null, null, control, null, null, null, null, null, null, null, null, null, green, null, null, null, null, null, null, control, control, null, null, green, control, null, red, control, null, null, null, null, null, green, null, red, control, green, null, null, null, null, control, null, null, null, green, control, red, null, null, null, red, control, null, null, null, null, green, null, green, control, null, control, null, red, null, null, null, control, red, null, null, null, null, null, null, null, green, green, null, green, control, null, control, null, green, green, control, null, red, null, null, null, null, red, null, null, null, null, red, null, null, null, null, null, green, control, null, null, control, control, control, null, null, null, null, red, control, null, control, null, null, null, red, null, null, green, null, null, null, null, red, null, null, control, control, control, null, null, null, null, control, control, green, null, red, green, null, null, null, green, null, green, null, green, null, null, control, null, null, null, null, red, null, null, null, red, null, red, null, green, null, null, red, null, control, control, null, null, null, null, control, red, null, null, null, null, red, red, green, null, null, control, null, null, green, null, red, null, red, control, green, green, null, green, null, null, green, null, null, null, null, null, null, null, null, null, null, null, control, control, red, control, null, red, null, null, green, null, green, control, null, null, null, red, red, red, null, null, red, control, null, null, null, control, null, red, control, null, null, null, null, null, red, null, red, null, null, null, null, null, control, green, null, control, control, control, null, green, null, null, green, control, green, null, null, null, null, null, null, null, null, null, green, null, null, null, null, red, red, null, null, null, red, null, null, null, null, null, green, null, null, null, null, green, null, control, control, green, green, null, control, null, green, red, control, null, green, control, control, red, null, null, control, red, null, green, control, control, red, null, red, green, control, null, null, control, null, null, null, red, red, null, null, null, control, null, null, null, green, null, green, null, control, red, red, green, red, null, null, control, control, null, null, null, control, null, null, null, null, null, null, null, red, green, null, null, null, red, null, control, green, green, null, null, red, null, null, null, control, null, null, null, green, green, red, null, null, null, red, null, null, green]> but was:<[null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null]>
	at org.junit.Assert.fail(Assert.java:89)
Tests on test(AVD) - 13 failed: There was 1 failure(s).
```

logs from device:

```
--------- beginning of main
10-22 23:00:44.069  4076  4109 I EppoSDK : setupMockRacServer host:http://localhost:4001
10-22 23:00:44.710  4076  4109 D EppoSDK : initializing client with host: http://localhost:4001
10-22 23:00:46.167  4076  4109 D EppoSDK : Attempting to request from baseUrl: http://localhost:4001
10-22 23:00:48.671  4076  4109 W EppoSDK : no configuration found for key: randomization_algo
10-22 23:00:48.672  4076  4109 W EppoSDK : no configuration found for key: randomization_algo
...
10-22 23:00:53.086  4076  4109 W EppoSDK : no configuration found for key: randomization_algo
10-22 23:00:53.087  4076  4109 W EppoSDK : no configuration found for key: randomization_algo
10-22 23:00:53.127  4076  4445 E EppoSDK : Unable to fetch from URL
10-22 23:00:53.128  4076  4445 E EppoSDK : initClient onError: Unable to fetch from URL
```