### PR TITLE
Include additional error information in emulator log

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,6 +40,20 @@ jobs:
       - name: Set up test data
         run: make test-data
 
+      - name: Wait for mock RAC DNS to resolve
+        run: |
+          for i in {1..15}
+          do
+            ip=$(dig +short us-central1-eppo-prod-312905.cloudfunctions.net)
+            if [[ -n "$ip" ]]; then
+              echo "Domain resolved to $ip after $i seconds"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Failed to resolve after 15 seconds"
+          exit 1
+
       - name: Spin up emulator and run tests
         id: testing
         uses: ReactiveCircus/android-emulator-runner@v2

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -133,9 +133,6 @@ public class EppoClientTest {
             deleteCacheFiles();
         }
 
-        // Android may struggle with IPV6 on GitHub Actions
-        EppoHttpClient.setIpV4Only(true);
-
         new EppoClient.Builder()
                 .application(ApplicationProvider.getApplicationContext())
                 .apiKey("mock-api-key")

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -133,6 +133,9 @@ public class EppoClientTest {
             deleteCacheFiles();
         }
 
+        // Android may struggle with IPV6 on GitHub Actions
+        EppoHttpClient.setIpV4Only(true);
+
         new EppoClient.Builder()
                 .application(ApplicationProvider.getApplicationContext())
                 .apiKey("mock-api-key")

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -148,7 +148,7 @@ public class EppoClientTest {
                     @Override
                     public void onError(String errorMessage) {
                         if (throwOnCallackError) {
-                            throw new RuntimeException("Unable to initialize");
+                            throw new RuntimeException("Unable to initialize: "+errorMessage);
                         }
                         lock.countDown();
                     }

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import static cloud.eppo.android.ConfigCacheFile.CACHE_FILE_NAME;
-import static cloud.eppo.android.util.Utils.logTag;
 
 import android.content.res.AssetManager;
 
@@ -44,8 +43,8 @@ import cloud.eppo.android.dto.SubjectAttributes;
 import cloud.eppo.android.dto.adapters.EppoValueAdapter;
 
 public class EppoClientTest {
-    private static final String TEST_HOST = "http://us-central1-eppo-prod-312905.cloudfunctions.net/serveGithubRacTestFile";
-    private static final String INVALID_HOST = "http://thisisabaddomainforthistest.com";
+    private static final String TEST_HOST = "https://us-central1-eppo-prod-312905.cloudfunctions.net/serveGithubRacTestFile";
+    private static final String INVALID_HOST = "https://thisisabaddomainforthistest.com";
     private Gson gson = new GsonBuilder()
             .registerTypeAdapter(EppoValue.class, new EppoValueAdapter())
             .registerTypeAdapter(AssignmentValueType.class, new AssignmentValueTypeAdapter(AssignmentValueType.STRING))

--- a/eppo/src/main/java/cloud/eppo/android/EppoHttpClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoHttpClient.java
@@ -4,14 +4,21 @@ import static cloud.eppo.android.util.Utils.logTag;
 
 import android.util.Log;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.io.IOException;
 import java.io.Reader;
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import okhttp3.Call;
 import okhttp3.Callback;
+import okhttp3.Dns;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -20,17 +27,46 @@ import okhttp3.Response;
 public class EppoHttpClient {
     private static final String TAG = logTag(EppoHttpClient.class);
 
-    private final OkHttpClient client = new OkHttpClient().newBuilder()
-            .connectTimeout(10, TimeUnit.SECONDS)
-            .readTimeout(10, TimeUnit.SECONDS)
-            .build();
+    private final OkHttpClient client;
 
     private final String baseUrl;
     private final String apiKey;
+    private static boolean ipV4Only = false;
 
     public EppoHttpClient(String baseUrl, String apiKey) {
         this.baseUrl = baseUrl;
         this.apiKey = apiKey;
+        this.client = buildOkHttpClient();
+    }
+
+    private static OkHttpClient buildOkHttpClient() {
+        OkHttpClient.Builder builder = new OkHttpClient().newBuilder()
+                .connectTimeout(10, TimeUnit.SECONDS)
+                .readTimeout(10, TimeUnit.SECONDS);
+
+        if (EppoHttpClient.ipV4Only) {
+            Log.d(TAG, "Setting Http Client to be IPV4 Only");
+            builder.dns(buildIpV4OnlyDns());
+        }
+
+        return builder.build();
+    }
+
+    private static Dns buildIpV4OnlyDns() {
+        return new Dns() {
+            @NotNull
+            @Override
+            public List<InetAddress> lookup(@NotNull String hostname) throws UnknownHostException {
+                List<InetAddress> allAddresses = Dns.SYSTEM.lookup(hostname);
+                List<InetAddress> ipv4Addresses = new ArrayList<>();
+                for (InetAddress address : allAddresses) {
+                    if (address.getAddress().length == 4) {
+                        ipv4Addresses.add(address);
+                    }
+                }
+                return ipv4Addresses;
+            }
+        };
     }
 
     public void get(String path, RequestCallback callback) {
@@ -69,6 +105,10 @@ public class EppoHttpClient {
                 callback.onFailure("Unable to fetch from URL "+httpUrl);
             }
         });
+    }
+
+    public static void setIpV4Only(boolean ipV4Only) {
+        EppoHttpClient.ipV4Only = ipV4Only;
     }
 }
 

--- a/eppo/src/main/java/cloud/eppo/android/EppoHttpClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoHttpClient.java
@@ -31,7 +31,6 @@ public class EppoHttpClient {
 
     private final String baseUrl;
     private final String apiKey;
-    private static boolean ipV4Only = false;
 
     public EppoHttpClient(String baseUrl, String apiKey) {
         this.baseUrl = baseUrl;
@@ -44,29 +43,7 @@ public class EppoHttpClient {
                 .connectTimeout(10, TimeUnit.SECONDS)
                 .readTimeout(10, TimeUnit.SECONDS);
 
-        if (EppoHttpClient.ipV4Only) {
-            Log.d(TAG, "Setting Http Client to be IPV4 Only");
-            builder.dns(buildIpV4OnlyDns());
-        }
-
         return builder.build();
-    }
-
-    private static Dns buildIpV4OnlyDns() {
-        return new Dns() {
-            @NotNull
-            @Override
-            public List<InetAddress> lookup(@NotNull String hostname) throws UnknownHostException {
-                List<InetAddress> allAddresses = Dns.SYSTEM.lookup(hostname);
-                List<InetAddress> ipv4Addresses = new ArrayList<>();
-                for (InetAddress address : allAddresses) {
-                    if (address.getAddress().length == 4) {
-                        ipv4Addresses.add(address);
-                    }
-                }
-                return ipv4Addresses;
-            }
-        };
     }
 
     public void get(String path, RequestCallback callback) {
@@ -105,10 +82,6 @@ public class EppoHttpClient {
                 callback.onFailure("Unable to fetch from URL "+httpUrl);
             }
         });
-    }
-
-    public static void setIpV4Only(boolean ipV4Only) {
-        EppoHttpClient.ipV4Only = ipV4Only;
     }
 }
 

--- a/eppo/src/main/java/cloud/eppo/android/EppoHttpClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoHttpClient.java
@@ -7,6 +7,7 @@ import android.util.Log;
 import java.io.IOException;
 import java.io.Reader;
 import java.net.HttpURLConnection;
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 import okhttp3.Call;
@@ -64,10 +65,7 @@ public class EppoHttpClient {
 
             @Override
             public void onFailure(Call call, IOException e) {
-                if (BuildConfig.DEBUG) {
-                    e.printStackTrace();
-                }
-                Log.e(TAG, "Http request failure", e);
+                Log.e(TAG, "Http request failure: "+e.getMessage()+" "+Arrays.toString(e.getStackTrace()), e);
                 callback.onFailure("Unable to fetch from URL "+httpUrl);
             }
         });

--- a/eppo/src/main/java/cloud/eppo/android/EppoHttpClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoHttpClient.java
@@ -46,7 +46,7 @@ public class EppoHttpClient {
             @Override
             public void onResponse(Call call, Response response) {
                 if (response.isSuccessful()) {
-                    Log.d(TAG, "Fetch successfull");
+                    Log.d(TAG, "Fetch successful");
                     callback.onSuccess(response.body().charStream());
                 } else {
                     switch (response.code()) {


### PR DESCRIPTION
**Ticket:** [FF-1133 - Harden waiting for RAC request in Android SDK Test](https://linear.app/eppo/issue/FF-1133/harden-waiting-for-rac-request-in-android-sdk-test)

**Motivation:** still getting weird failures (see: https://github.com/Eppo-exp/sdk-test-data/actions/runs/6661079552)

I want more information to make it in the uploaded log, and I noticed we only allow 2 seconds for the RAC request to finish and then silently continue on our way. This change increases the timeout to be more generous and throws an error if it does time out, so we're not left scratching our heads.

I added a bit of extra logging, too, which revealed that sometimes the action cannot reach the Google Cloud Function. So I added a little loop to wait up to 15 seconds for DNS to resolve before proceeding.

<img width="902" alt="image" src="https://github.com/Eppo-exp/android-sdk/assets/417605/162e4b83-b1b5-49c3-bf45-acfa30f629d1">


I also saw the above check pass but android emulator fail, so I switched to HTTPS protocol thinking that may play nicer with DNS.
