### PR TITLE
bump to 1.0.2

### DIFF
--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "cloud.eppo"
-version = "1.0.1"
+version = "1.0.2"
 
 android {
     compileSdk 33


### PR DESCRIPTION
bumping to 1.0.2 in order to publish a new release at that tag; this will include graceful mode to suppress exceptions.