### PR TITLE
Add semver support (FF-1573)

### DIFF
--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -71,6 +71,7 @@ dependencies {
     androidTestImplementation "commons-io:commons-io:${versions.commonsio}"
     implementation("com.google.code.gson:gson:${versions.gson}")
     implementation("com.squareup.okhttp3:okhttp:${versions.okhttp}")
+    implementation("com.github.zafarkhaja:java-semver:0.10.2")
 }
 
 publishing {

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -262,7 +262,7 @@ public class EppoClientTest {
 
             // wait for a bit since cache file is loaded asynchronously
             System.out.println("Sleeping for a bit to wait for cache population to complete");
-            Thread.sleep(5000);
+            Thread.sleep(10000);
 
             // Then reinitialize with a bad host so we know it's using the cached RAC built from the first initialization
             initClient(INVALID_HOST, false, false, false); // invalid port to force to use cache

--- a/eppo/src/main/java/cloud/eppo/android/dto/EppoValue.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/EppoValue.java
@@ -57,16 +57,8 @@ public class EppoValue {
         return  new EppoValue(EppoValueType.Null);
     }
 
-    public int intValue() {
-        return Integer.parseInt(value, 10);
-    }
-
     public double doubleValue() {
         return Double.parseDouble(value);
-    }
-
-    public long longValue() {
-        return Long.parseLong(value, 10);
     }
 
     public String stringValue() {
@@ -87,7 +79,7 @@ public class EppoValue {
 
     public boolean isNumeric() {
         try {
-            Long.parseLong(value, 10);
+            Double.parseDouble(value);
             return true;
         } catch (Exception e) {
             return false;

--- a/eppo/src/test/java/cloud/eppo/android/RuleEvaluatorTest.java
+++ b/eppo/src/test/java/cloud/eppo/android/RuleEvaluatorTest.java
@@ -43,6 +43,21 @@ public class RuleEvaluatorTest {
         addConditionToRule(TargetingRule, condition2);
     }
 
+    public void addSemVerConditionToRule(TargetingRule TargetingRule) {
+        TargetingCondition condition1 = new TargetingCondition();
+        condition1.setValue(EppoValue.valueOf("1.5.0"));
+        condition1.setAttribute("appVersion");
+        condition1.setOperator(OperatorType.GreaterThanEqualTo);
+
+        TargetingCondition condition2 = new TargetingCondition();
+        condition2.setValue(EppoValue.valueOf("2.2.0"));
+        condition2.setAttribute("appVersion");
+        condition2.setOperator(OperatorType.LessThan);
+
+        addConditionToRule(TargetingRule, condition1);
+        addConditionToRule(TargetingRule, condition2);
+    }
+
     public void addRegexConditionToRule(TargetingRule TargetingRule) {
         TargetingCondition condition = new TargetingCondition();
         condition.setValue(EppoValue.valueOf("[a-z]+"));
@@ -131,6 +146,18 @@ public class RuleEvaluatorTest {
         assertEquals(targetingRule, RuleEvaluator.findMatchingRule(subjectAttributes, targetingRules));
     }
 
+    @Test
+    public void testMatchesAnyRuleWhenRuleMatchesWithSemVer() {
+        List<TargetingRule> targetingRules = new ArrayList<>();
+        TargetingRule targetingRule = createRule(new ArrayList<>());
+        addSemVerConditionToRule(targetingRule);
+        targetingRules.add(targetingRule);
+
+        SubjectAttributes subjectAttributes = new SubjectAttributes();
+        subjectAttributes.put("appVersion", "1.15.5");
+
+        assertEquals(targetingRule, RuleEvaluator.findMatchingRule(subjectAttributes, targetingRules));
+    }
     
     @Test
     public void testMatchesAnyRuleWhenThrowInvalidSubjectAttribute() {


### PR DESCRIPTION
## context

Related implementation to Java (https://github.com/Eppo-exp/java-server-sdk/commit/11c33e30cb7a302edb7082ea42f7695a8a0dc046). Since we are targeting android api 21, we are limited to an older API.

isPresent, which require API level 24 or higher, you'll need to find alternative approaches. The Optional class and its methods were introduced in Java 8, and Android started supporting Java 8 language features from API level 24 onwards. This means methods like isPresent and isEmpty are not directly available on devices running lower API levels.

## description

implementation of semver support using available APIs.