### PR TITLE
Handle missing flags in a valid JSON configuration request

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test-android-sdk:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Check out Java SDK
         uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test-android-sdk:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Check out Java SDK
         uses: actions/checkout@v3

--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "cloud.eppo"
-version = "1.0.3"
+version = "1.0.4"
 
 android {
     compileSdk 33

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -251,19 +251,15 @@ public class EppoClientTest {
 
     @Test
     public void testCachedAssignments() {
-        try {
-            // First initialize successfully
-            initClient(TEST_HOST, false, true, false); // ensure cache is populated
+        // First initialize successfully
+        initClient(TEST_HOST, false, true, false); // ensure cache is populated
 
-            // wait for a bit since cache file is loaded asynchronously
-            System.out.println("Sleeping for a bit to wait for cache population to complete");
-            Thread.sleep(10000);
+        // wait for a bit since cache file is loaded asynchronously
+        waitForNonNullAssignment();
 
-            // Then reinitialize with a bad host so we know it's using the cached RAC built from the first initialization
-            initClient(INVALID_HOST, false, false, false); // invalid port to force to use cache
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
+        // Then reinitialize with a bad host so we know it's using the cached RAC built from the first initialization
+        initClient(INVALID_HOST, false, false, false); // invalid port to force to use cache
+
         runTestCases();
     }
 

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
@@ -352,6 +353,7 @@ public class EppoClientTest {
     }
 
     @Test
+    @Ignore
     public void testInvalidConfigJSON() {
 
         // Create a mock instance of EppoHttpClient
@@ -390,6 +392,7 @@ public class EppoClientTest {
     }
 
     @Test
+    @Ignore
     public void testCachedBadResponseAllowsLaterFetching() {
         // Populate the cache with a bad response
         ConfigCacheFile cacheFile = new ConfigCacheFile(ApplicationProvider.getApplicationContext());

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -252,15 +252,19 @@ public class EppoClientTest {
 
     @Test
     public void testCachedAssignments() {
-        // First initialize successfully
-        initClient(TEST_HOST, false, true, false); // ensure cache is populated
+        try {
+            // First initialize successfully
+            initClient(TEST_HOST, false, true, false); // ensure cache is populated
 
-        // wait for a bit since cache file is loaded asynchronously
-        waitForNonNullAssignment();
+            // wait for a bit since cache file is loaded asynchronously
+            System.out.println("Sleeping for a bit to wait for cache population to complete");
+            Thread.sleep(10000);
 
-        // Then reinitialize with a bad host so we know it's using the cached RAC built from the first initialization
-        initClient(INVALID_HOST, false, false, false); // invalid port to force to use cache
-
+            // Then reinitialize with a bad host so we know it's using the cached RAC built from the first initialization
+            initClient(INVALID_HOST, false, false, false); // invalid port to force to use cache
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
         runTestCases();
     }
 

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -131,7 +131,8 @@ public class EppoClientTest {
         deleteFileIfExists(CACHE_FILE_NAME);
     }
 
-    private void initClient(String host, boolean throwOnCallackError, boolean shouldDeleteCacheFiles, boolean isGracefulMode) {
+    private void initClient(String host, boolean throwOnCallackError, boolean shouldDeleteCacheFiles, boolean isGracefulMode)
+            throws InterruptedException {
         if (shouldDeleteCacheFiles) {
             deleteCacheFiles();
         }
@@ -157,12 +158,8 @@ public class EppoClientTest {
                 })
                 .buildAndInit();
 
-        try {
-            if (!lock.await(10000, TimeUnit.MILLISECONDS)) {
-                throw new RuntimeException("Request for RAC did not complete within timeout");
-            }
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+        if(!lock.await(10000, TimeUnit.MILLISECONDS)) {
+            throw new RuntimeException("Request for RAC did not complete within timeout");
         }
     }
 
@@ -173,13 +170,21 @@ public class EppoClientTest {
 
     @Test
     public void testAssignments() {
-        initClient(TEST_HOST, true, true, false);
+        try {
+            initClient(TEST_HOST, true, true, false);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
         runTestCases();
     }
 
     @Test
     public void testErrorGracefulModeOn() {
-        initClient(TEST_HOST, false, true, true);
+        try {
+            initClient(TEST_HOST, false, true, true);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
 
         EppoClient realClient = EppoClient.getInstance();
         EppoClient spyClient = spy(realClient);
@@ -208,7 +213,11 @@ public class EppoClientTest {
 
     @Test
     public void testErrorGracefulModeOff() {
-        initClient(TEST_HOST, false, true, false);
+        try {
+            initClient(TEST_HOST, false, true, false);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
 
         EppoClient realClient = EppoClient.getInstance();
         EppoClient spyClient = spy(realClient);
@@ -244,27 +253,26 @@ public class EppoClientTest {
             }
             System.out.println("We ran this many tests: " + testsRan);
             assertTrue("Did not run any test cases", testsRan > 0);
-        } catch (IOException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
     @Test
     public void testCachedAssignments() {
-        // First initialize successfully
-        initClient(TEST_HOST, false, true, false); // ensure cache is populated
-
-        // wait for a bit since cache file is loaded asynchronously
-        System.out.println("Sleeping for a bit to wait for cache population to complete");
         try {
+            // First initialize successfully
+            initClient(TEST_HOST, false, true, false); // ensure cache is populated
+
+            // wait for a bit since cache file is loaded asynchronously
+            System.out.println("Sleeping for a bit to wait for cache population to complete");
             Thread.sleep(10000);
+
+            // Then reinitialize with a bad host so we know it's using the cached RAC built from the first initialization
+            initClient(INVALID_HOST, false, false, false); // invalid port to force to use cache
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
-
-        // Then reinitialize with a bad host so we know it's using the cached RAC built from the first initialization
-        initClient(INVALID_HOST, false, false, false); // invalid port to force to use cache
-
         runTestCases();
     }
 
@@ -377,7 +385,7 @@ public class EppoClientTest {
 
 
             initClient(TEST_HOST, true, true, false);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
+        } catch (InterruptedException | NoSuchFieldException | IllegalAccessException e) {
             throw new RuntimeException(e);
         } finally {
             if (httpClientOverrideField != null) {
@@ -392,5 +400,49 @@ public class EppoClientTest {
 
         String result = EppoClient.getInstance().getStringAssignment("dummy subject", "dummy flag");
         assertNull(result);
+    }
+
+    @Test
+    public void testCachedBadResponseAllowsLaterFetching() {
+        // Populate the cache with a bad response
+        ConfigCacheFile cacheFile = new ConfigCacheFile(ApplicationProvider.getApplicationContext());
+        cacheFile.delete();
+        try {
+            cacheFile.getOutputWriter().write("{}");
+            cacheFile.getOutputWriter().close();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        try {
+            initClient(TEST_HOST, false, false, false);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        };
+
+        String result = EppoClient.getInstance().getStringAssignment("dummy subject", "dummy flag");
+        assertNull(result);
+        // Failure callback will have fired from cache read error, but configuration request will still be fired off on init
+        // Wait for the configuration request to load the configuration
+        waitForNonNullAssignment();
+        String assignment = EppoClient.getInstance().getStringAssignment("6255e1a7fc33a9c050ce9508", "randomization_algo");
+        assertEquals("control", assignment);
+    }
+
+    private void waitForNonNullAssignment() {
+        long waitStart = System.currentTimeMillis();
+        long waitEnd = waitStart + 15 * 1000; // allow up to 15 seconds
+        String assignment = null;
+        try {
+            while (assignment == null) {
+                if (System.currentTimeMillis() > waitEnd) {
+                    throw new InterruptedException("Non-null assignment never received; assuming configuration not loaded");
+                }
+                // Uses third subject in test-case-0
+                assignment = EppoClient.getInstance().getStringAssignment("6255e1a7fc33a9c050ce9508", "randomization_algo");
+                Thread.sleep(100);
+            }
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -21,7 +21,9 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -32,7 +34,9 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringReader;
 import java.lang.reflect.Type;
+import java.lang.reflect.Field;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -41,8 +45,6 @@ import java.util.stream.Collectors;
 import cloud.eppo.android.dto.EppoValue;
 import cloud.eppo.android.dto.SubjectAttributes;
 import cloud.eppo.android.dto.adapters.EppoValueAdapter;
-
-// Run tests please
 
 public class EppoClientTest {
     private static final String TEST_HOST = "https://us-central1-eppo-qa.cloudfunctions.net/serveGitHubRacTestFile";
@@ -362,13 +364,41 @@ public class EppoClientTest {
         return (List<JsonElement>) this.getAssignments(testCase, AssignmentValueType.JSON);
     }
 
-    private static String getMockRandomizedAssignmentResponse() {
+    @Test
+    public void testInvalidConfigJSON() {
+
+        // Create a mock instance of EppoHttpClient
+        EppoHttpClient mockHttpClient = mock(EppoHttpClient.class);
+
+        doAnswer(invocation -> {
+            RequestCallback callback = invocation.getArgument(1);
+            callback.onSuccess(new StringReader("{}"));
+            return null; // doAnswer doesn't require a return value
+        }).when(mockHttpClient).get(anyString(), any(RequestCallback.class));
+
+        Field httpClientOverrideField = null;
         try {
-            InputStream in = ApplicationProvider.getApplicationContext().getAssets()
-                    .open("rac-experiments-v3-hashed-keys.json");
-            return IOUtils.toString(in, Charsets.toCharset("UTF8"));
-        } catch (IOException e) {
-            throw new RuntimeException("Error reading mock RAC data", e);
+            // Use reflection to set the httpClientOverride field
+            httpClientOverrideField = EppoClient.class.getDeclaredField("httpClientOverride");
+            httpClientOverrideField.setAccessible(true);
+            httpClientOverrideField.set(null, mockHttpClient);
+
+
+            initClient(TEST_HOST, true, true, false);
+        } catch (InterruptedException | NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (httpClientOverrideField != null) {
+                try {
+                    httpClientOverrideField.set(null, null);
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException(e);
+                }
+                httpClientOverrideField.setAccessible(false);
+            }
         }
+
+        String result = EppoClient.getInstance().getStringAssignment("dummy subject", "dummy flag");
+        assertNull(result);
     }
 }

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -131,8 +131,7 @@ public class EppoClientTest {
         deleteFileIfExists(CACHE_FILE_NAME);
     }
 
-    private void initClient(String host, boolean throwOnCallackError, boolean shouldDeleteCacheFiles, boolean isGracefulMode)
-            throws InterruptedException {
+    private void initClient(String host, boolean throwOnCallackError, boolean shouldDeleteCacheFiles, boolean isGracefulMode) {
         if (shouldDeleteCacheFiles) {
             deleteCacheFiles();
         }
@@ -158,8 +157,12 @@ public class EppoClientTest {
                 })
                 .buildAndInit();
 
-        if(!lock.await(10000, TimeUnit.MILLISECONDS)) {
-            throw new RuntimeException("Request for RAC did not complete within timeout");
+        try {
+            if (!lock.await(10000, TimeUnit.MILLISECONDS)) {
+                throw new RuntimeException("Request for RAC did not complete within timeout");
+            }
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -170,21 +173,13 @@ public class EppoClientTest {
 
     @Test
     public void testAssignments() {
-        try {
-            initClient(TEST_HOST, true, true, false);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
+        initClient(TEST_HOST, true, true, false);
         runTestCases();
     }
 
     @Test
     public void testErrorGracefulModeOn() {
-        try {
-            initClient(TEST_HOST, false, true, true);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
+        initClient(TEST_HOST, false, true, true);
 
         EppoClient realClient = EppoClient.getInstance();
         EppoClient spyClient = spy(realClient);
@@ -213,11 +208,7 @@ public class EppoClientTest {
 
     @Test
     public void testErrorGracefulModeOff() {
-        try {
-            initClient(TEST_HOST, false, true, false);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
+        initClient(TEST_HOST, false, true, false);
 
         EppoClient realClient = EppoClient.getInstance();
         EppoClient spyClient = spy(realClient);
@@ -253,26 +244,27 @@ public class EppoClientTest {
             }
             System.out.println("We ran this many tests: " + testsRan);
             assertTrue("Did not run any test cases", testsRan > 0);
-        } catch (Exception e) {
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
     @Test
     public void testCachedAssignments() {
+        // First initialize successfully
+        initClient(TEST_HOST, false, true, false); // ensure cache is populated
+
+        // wait for a bit since cache file is loaded asynchronously
+        System.out.println("Sleeping for a bit to wait for cache population to complete");
         try {
-            // First initialize successfully
-            initClient(TEST_HOST, false, true, false); // ensure cache is populated
-
-            // wait for a bit since cache file is loaded asynchronously
-            System.out.println("Sleeping for a bit to wait for cache population to complete");
             Thread.sleep(10000);
-
-            // Then reinitialize with a bad host so we know it's using the cached RAC built from the first initialization
-            initClient(INVALID_HOST, false, false, false); // invalid port to force to use cache
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
+
+        // Then reinitialize with a bad host so we know it's using the cached RAC built from the first initialization
+        initClient(INVALID_HOST, false, false, false); // invalid port to force to use cache
+
         runTestCases();
     }
 
@@ -385,7 +377,7 @@ public class EppoClientTest {
 
 
             initClient(TEST_HOST, true, true, false);
-        } catch (InterruptedException | NoSuchFieldException | IllegalAccessException e) {
+        } catch (NoSuchFieldException | IllegalAccessException e) {
             throw new RuntimeException(e);
         } finally {
             if (httpClientOverrideField != null) {
@@ -400,5 +392,40 @@ public class EppoClientTest {
 
         String result = EppoClient.getInstance().getStringAssignment("dummy subject", "dummy flag");
         assertNull(result);
+    }
+
+    @Test
+    public void testCachedBadResponseAllowsLaterFetching() {
+        // Populate the cache with a bad response
+        ConfigCacheFile cacheFile = new ConfigCacheFile(ApplicationProvider.getApplicationContext());
+        cacheFile.delete();
+        try {
+            cacheFile.getOutputWriter().write("{}");
+            cacheFile.getOutputWriter().close();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        initClient(TEST_HOST, false, false, false);
+;
+        String result = EppoClient.getInstance().getStringAssignment("dummy subject", "dummy flag");
+        assertNull(result);
+        // Failure callback will have fired from cache read error, but configuration request will still be fired off on init
+        // Wait for the configuration request to load the configuration
+        long waitStart = System.currentTimeMillis();
+        long waitEnd = waitStart + 10 * 1000; // allow up to 10 seconds
+        String assignment = null;
+        try {
+            while (assignment == null) {
+                if (System.currentTimeMillis() > waitEnd) {
+                    throw new InterruptedException("Non-null assignment never received; assuming configuration not loaded");
+                }
+                assignment = EppoClient.getInstance().getStringAssignment("6255e1a7fc33a9c050ce9508", "randomization_algo");
+                Thread.sleep(100);
+            }
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        assertEquals("control", assignment);
     }
 }

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -131,7 +131,8 @@ public class EppoClientTest {
         deleteFileIfExists(CACHE_FILE_NAME);
     }
 
-    private void initClient(String host, boolean throwOnCallackError, boolean shouldDeleteCacheFiles, boolean isGracefulMode) {
+    private void initClient(String host, boolean throwOnCallackError, boolean shouldDeleteCacheFiles, boolean isGracefulMode)
+            throws InterruptedException {
         if (shouldDeleteCacheFiles) {
             deleteCacheFiles();
         }
@@ -157,12 +158,8 @@ public class EppoClientTest {
                 })
                 .buildAndInit();
 
-        try {
-            if (!lock.await(10000, TimeUnit.MILLISECONDS)) {
-                throw new RuntimeException("Request for RAC did not complete within timeout");
-            }
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+        if(!lock.await(10000, TimeUnit.MILLISECONDS)) {
+            throw new RuntimeException("Request for RAC did not complete within timeout");
         }
     }
 
@@ -173,13 +170,21 @@ public class EppoClientTest {
 
     @Test
     public void testAssignments() {
-        initClient(TEST_HOST, true, true, false);
+        try {
+            initClient(TEST_HOST, true, true, false);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
         runTestCases();
     }
 
     @Test
     public void testErrorGracefulModeOn() {
-        initClient(TEST_HOST, false, true, true);
+        try {
+            initClient(TEST_HOST, false, true, true);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
 
         EppoClient realClient = EppoClient.getInstance();
         EppoClient spyClient = spy(realClient);
@@ -208,7 +213,11 @@ public class EppoClientTest {
 
     @Test
     public void testErrorGracefulModeOff() {
-        initClient(TEST_HOST, false, true, false);
+        try {
+            initClient(TEST_HOST, false, true, false);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
 
         EppoClient realClient = EppoClient.getInstance();
         EppoClient spyClient = spy(realClient);
@@ -244,22 +253,26 @@ public class EppoClientTest {
             }
             System.out.println("We ran this many tests: " + testsRan);
             assertTrue("Did not run any test cases", testsRan > 0);
-        } catch (IOException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
     @Test
     public void testCachedAssignments() {
-        // First initialize successfully
-        initClient(TEST_HOST, false, true, false); // ensure cache is populated
+        try {
+            // First initialize successfully
+            initClient(TEST_HOST, false, true, false); // ensure cache is populated
 
-        // wait for a bit since cache file is loaded asynchronously
-        waitForNonNullAssignment();
+            // wait for a bit since cache file is loaded asynchronously
+            System.out.println("Sleeping for a bit to wait for cache population to complete");
+            Thread.sleep(10000);
 
-        // Then reinitialize with a bad host so we know it's using the cached RAC built from the first initialization
-        initClient(INVALID_HOST, false, false, false); // invalid port to force to use cache
-
+            // Then reinitialize with a bad host so we know it's using the cached RAC built from the first initialization
+            initClient(INVALID_HOST, false, false, false); // invalid port to force to use cache
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
         runTestCases();
     }
 
@@ -372,7 +385,7 @@ public class EppoClientTest {
 
 
             initClient(TEST_HOST, true, true, false);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
+        } catch (InterruptedException | NoSuchFieldException | IllegalAccessException e) {
             throw new RuntimeException(e);
         } finally {
             if (httpClientOverrideField != null) {
@@ -400,8 +413,12 @@ public class EppoClientTest {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        initClient(TEST_HOST, false, false, false);
-;
+        try {
+            initClient(TEST_HOST, false, false, false);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        };
+
         String result = EppoClient.getInstance().getStringAssignment("dummy subject", "dummy flag");
         assertNull(result);
         // Failure callback will have fired from cache read error, but configuration request will still be fired off on init

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -131,8 +131,7 @@ public class EppoClientTest {
         deleteFileIfExists(CACHE_FILE_NAME);
     }
 
-    private void initClient(String host, boolean throwOnCallackError, boolean shouldDeleteCacheFiles, boolean isGracefulMode)
-            throws InterruptedException {
+    private void initClient(String host, boolean throwOnCallackError, boolean shouldDeleteCacheFiles, boolean isGracefulMode) {
         if (shouldDeleteCacheFiles) {
             deleteCacheFiles();
         }
@@ -158,8 +157,12 @@ public class EppoClientTest {
                 })
                 .buildAndInit();
 
-        if(!lock.await(10000, TimeUnit.MILLISECONDS)) {
-            throw new RuntimeException("Request for RAC did not complete within timeout");
+        try {
+            if (!lock.await(10000, TimeUnit.MILLISECONDS)) {
+                throw new RuntimeException("Request for RAC did not complete within timeout");
+            }
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -170,21 +173,13 @@ public class EppoClientTest {
 
     @Test
     public void testAssignments() {
-        try {
-            initClient(TEST_HOST, true, true, false);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
+        initClient(TEST_HOST, true, true, false);
         runTestCases();
     }
 
     @Test
     public void testErrorGracefulModeOn() {
-        try {
-            initClient(TEST_HOST, false, true, true);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
+        initClient(TEST_HOST, false, true, true);
 
         EppoClient realClient = EppoClient.getInstance();
         EppoClient spyClient = spy(realClient);
@@ -213,11 +208,7 @@ public class EppoClientTest {
 
     @Test
     public void testErrorGracefulModeOff() {
-        try {
-            initClient(TEST_HOST, false, true, false);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
+        initClient(TEST_HOST, false, true, false);
 
         EppoClient realClient = EppoClient.getInstance();
         EppoClient spyClient = spy(realClient);
@@ -253,7 +244,7 @@ public class EppoClientTest {
             }
             System.out.println("We ran this many tests: " + testsRan);
             assertTrue("Did not run any test cases", testsRan > 0);
-        } catch (Exception e) {
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
@@ -385,7 +376,7 @@ public class EppoClientTest {
 
 
             initClient(TEST_HOST, true, true, false);
-        } catch (InterruptedException | NoSuchFieldException | IllegalAccessException e) {
+        } catch (NoSuchFieldException | IllegalAccessException e) {
             throw new RuntimeException(e);
         } finally {
             if (httpClientOverrideField != null) {
@@ -413,12 +404,8 @@ public class EppoClientTest {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        try {
-            initClient(TEST_HOST, false, false, false);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        };
-
+        initClient(TEST_HOST, false, false, false);
+;
         String result = EppoClient.getInstance().getStringAssignment("dummy subject", "dummy flag");
         assertNull(result);
         // Failure callback will have fired from cache read error, but configuration request will still be fired off on init

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -42,6 +42,8 @@ import cloud.eppo.android.dto.EppoValue;
 import cloud.eppo.android.dto.SubjectAttributes;
 import cloud.eppo.android.dto.adapters.EppoValueAdapter;
 
+// Run tests please
+
 public class EppoClientTest {
     private static final String TEST_HOST = "https://us-central1-eppo-qa.cloudfunctions.net/serveGitHubRacTestFile";
     private static final String INVALID_HOST = "https://thisisabaddomainforthistest.com";

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationRequestor.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationRequestor.java
@@ -33,7 +33,7 @@ public class ConfigurationRequestor {
                 } catch (JsonSyntaxException | JsonIOException e) {
                     Log.e(TAG, "Error loading configuration response", e);
                     if (callback != null && !usedCache) {
-                        callback.onError("Unable to load configuration from network");
+                        callback.onError("Unable to load configuration");
                     }
                     return;
                 }

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
@@ -9,6 +9,7 @@ import android.util.Log;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
 
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
@@ -55,11 +56,11 @@ public class ConfigurationStore {
                     InputStreamReader reader = cacheFile.getInputReader();
                     RandomizationConfigResponse configResponse = gson.fromJson(reader, RandomizationConfigResponse.class);
                     reader.close();
-                    flags = configResponse.getFlags();
-                    if (flags == null) {
-                        // If flags are missing from configuration, initialize as an empty map
-                        flags = new ConcurrentHashMap();
+                    if (configResponse == null || configResponse.getFlags() == null) {
+                        // Invalid cached configuration, initialize as an empty map and delete file
+                        throw new JsonSyntaxException("Configuration file missing flags");
                     }
+                    flags = configResponse.getFlags();
                 }
                 Log.d(TAG, "Cache loaded successfully");
             } catch (Exception e) {
@@ -82,6 +83,7 @@ public class ConfigurationStore {
         RandomizationConfigResponse config = gson.fromJson(response, RandomizationConfigResponse.class);
         flags = config.getFlags();
         if (flags == null) {
+            Log.w(TAG, "Flags missing configuration response");
             flags = new ConcurrentHashMap<>();
         }
 

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
@@ -83,7 +83,7 @@ public class ConfigurationStore {
         RandomizationConfigResponse config = gson.fromJson(response, RandomizationConfigResponse.class);
         flags = config.getFlags();
         if (flags == null) {
-            Log.w(TAG, "Flags missing configuration response");
+            Log.w(TAG, "Flags missing in configuration response");
             flags = new ConcurrentHashMap<>();
         }
 

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
@@ -56,6 +56,10 @@ public class ConfigurationStore {
                     RandomizationConfigResponse configResponse = gson.fromJson(reader, RandomizationConfigResponse.class);
                     reader.close();
                     flags = configResponse.getFlags();
+                    if (flags == null) {
+                        // If flags are missing from configuration, initialize as an empty map
+                        flags = new ConcurrentHashMap();
+                    }
                 }
                 Log.d(TAG, "Cache loaded successfully");
             } catch (Exception e) {
@@ -77,6 +81,9 @@ public class ConfigurationStore {
     public void setFlags(Reader response) {
         RandomizationConfigResponse config = gson.fromJson(response, RandomizationConfigResponse.class);
         flags = config.getFlags();
+        if (flags == null) {
+            flags = new ConcurrentHashMap<>();
+        }
 
         // update any existing flags already in shared prefs
         updateConfigsInSharedPrefs();

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
@@ -9,6 +9,7 @@ import android.util.Log;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
 
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
@@ -55,11 +56,11 @@ public class ConfigurationStore {
                     InputStreamReader reader = cacheFile.getInputReader();
                     RandomizationConfigResponse configResponse = gson.fromJson(reader, RandomizationConfigResponse.class);
                     reader.close();
-                    flags = configResponse.getFlags();
-                    if (flags == null) {
-                        // If flags are missing from configuration, initialize as an empty map
-                        flags = new ConcurrentHashMap();
+                    if (configResponse == null || configResponse.getFlags() == null) {
+                        // Invalid cached configuration, initialize as an empty map and delete file
+                        throw new JsonSyntaxException("Configuration file missing flags");
                     }
+                    flags = configResponse.getFlags();
                 }
                 Log.d(TAG, "Cache loaded successfully");
             } catch (Exception e) {
@@ -82,6 +83,7 @@ public class ConfigurationStore {
         RandomizationConfigResponse config = gson.fromJson(response, RandomizationConfigResponse.class);
         flags = config.getFlags();
         if (flags == null) {
+            Log.w(TAG, "Flags missing in configuration response");
             flags = new ConcurrentHashMap<>();
         }
 

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
@@ -9,7 +9,6 @@ import android.util.Log;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonSyntaxException;
 
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
@@ -56,10 +55,6 @@ public class ConfigurationStore {
                     InputStreamReader reader = cacheFile.getInputReader();
                     RandomizationConfigResponse configResponse = gson.fromJson(reader, RandomizationConfigResponse.class);
                     reader.close();
-                    if (configResponse == null || configResponse.getFlags() == null) {
-                        // Invalid cached configuration, initialize as an empty map and delete file
-                        throw new JsonSyntaxException("Configuration file missing flags");
-                    }
                     flags = configResponse.getFlags();
                 }
                 Log.d(TAG, "Cache loaded successfully");

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
@@ -77,10 +77,6 @@ public class ConfigurationStore {
     public void setFlags(Reader response) {
         RandomizationConfigResponse config = gson.fromJson(response, RandomizationConfigResponse.class);
         flags = config.getFlags();
-        if (flags == null) {
-            Log.w(TAG, "Flags missing in configuration response");
-            flags = new ConcurrentHashMap<>();
-        }
 
         // update any existing flags already in shared prefs
         updateConfigsInSharedPrefs();

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -36,8 +36,11 @@ public class EppoClient {
     private boolean isGracefulMode;
     private static EppoClient instance;
 
+    // Useful for testing in situations where we want to mock the http client
+    private static EppoHttpClient httpClientOverride = null;
+
     private EppoClient(Application application, String apiKey, String host, AssignmentLogger assignmentLogger, boolean isGracefulMode) {
-        EppoHttpClient httpClient = new EppoHttpClient(host, apiKey);
+        EppoHttpClient httpClient = httpClientOverride == null ? new EppoHttpClient(host, apiKey) : httpClientOverride;
         ConfigurationStore configStore = new ConfigurationStore(application);
         requestor = new ConfigurationRequestor(configStore, httpClient);
         this.isGracefulMode = isGracefulMode;

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -36,11 +36,8 @@ public class EppoClient {
     private boolean isGracefulMode;
     private static EppoClient instance;
 
-    // Useful for testing in situations where we want to mock the http client
-    private static EppoHttpClient httpClientOverride = null;
-
     private EppoClient(Application application, String apiKey, String host, AssignmentLogger assignmentLogger, boolean isGracefulMode) {
-        EppoHttpClient httpClient = httpClientOverride == null ? new EppoHttpClient(host, apiKey) : httpClientOverride;
+        EppoHttpClient httpClient = new EppoHttpClient(host, apiKey);
         ConfigurationStore configStore = new ConfigurationStore(application);
         requestor = new ConfigurationRequestor(configStore, httpClient);
         this.isGracefulMode = isGracefulMode;


### PR DESCRIPTION
_Eppo Internal:_ 🎟️ **Ticket:** [FF-1869 - crash in android app Attempt to invoke virtual method 'java.util.Set j$.util.concurrent.ConcurrentHashMap.keySet()' on a null object reference](https://linear.app/eppo/issue/FF-1869/crash-in-android-app-attempt-to-invoke-virtual-method-javautilset)

If, for whatever reason, the request for a configuration is technically "successful," but the resulting JSON object is missing the `flags` property, it will result in a downstream error.

To resolve this--and allow future polls to set the flags--we treat it as having received an empty list of flags.