### PR TITLE
Add @SerializedName labels to dto to make json->object mapping explicit. (FF-1869)

### DIFF
--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "cloud.eppo"
-version = "1.0.2"
+version = "1.0.3"
 
 android {
     compileSdk 33

--- a/eppo/src/main/java/cloud/eppo/android/dto/Allocation.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/Allocation.java
@@ -3,7 +3,10 @@ package cloud.eppo.android.dto;
 import java.util.List;
 
 public class Allocation {
+    @SerializedName("percentExposure")
     private float percentExposure;
+
+    @SerializedName("variations")
     private List<Variation> variations;
 
     public float getPercentExposure() {

--- a/eppo/src/main/java/cloud/eppo/android/dto/Allocation.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/Allocation.java
@@ -1,6 +1,7 @@
 package cloud.eppo.android.dto;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
 
 public class Allocation {
     @SerializedName("percentExposure")

--- a/eppo/src/main/java/cloud/eppo/android/dto/FlagConfig.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/FlagConfig.java
@@ -5,10 +5,19 @@ import java.util.Map;
 import java.util.HashMap;
 
 public class FlagConfig {
+    @SerializedName("subjectShards")
     private int subjectShards;
+
+    @SerializedName("enabled")
     private boolean enabled;
+
+    @SerializedName("typedOverrides")
     private Map<String, String> typedOverrides = new HashMap<>();
+
+    @SerializedName("rules")
     private List<TargetingRule> rules;
+
+    @SerializedName("allocations")
     private Map<String, Allocation> allocations;
 
     public int getSubjectShards() {

--- a/eppo/src/main/java/cloud/eppo/android/dto/FlagConfig.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/FlagConfig.java
@@ -1,5 +1,7 @@
 package cloud.eppo.android.dto;
 
+import com.google.gson.annotations.SerializedName;
+
 import java.util.List;
 import java.util.Map;
 import java.util.HashMap;

--- a/eppo/src/main/java/cloud/eppo/android/dto/RandomizationConfigResponse.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/RandomizationConfigResponse.java
@@ -1,6 +1,7 @@
 package cloud.eppo.android.dto;
 
 import java.util.concurrent.ConcurrentHashMap;
+import com.google.gson.annotations.SerializedName;
 
 public class RandomizationConfigResponse {
     @SerializedName("flags")

--- a/eppo/src/main/java/cloud/eppo/android/dto/RandomizationConfigResponse.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/RandomizationConfigResponse.java
@@ -3,6 +3,7 @@ package cloud.eppo.android.dto;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class RandomizationConfigResponse {
+    @SerializedName("flags")
     private ConcurrentHashMap<String, FlagConfig> flags;
 
     public ConcurrentHashMap<String, FlagConfig> getFlags() {

--- a/eppo/src/main/java/cloud/eppo/android/dto/ShardRange.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/ShardRange.java
@@ -1,5 +1,7 @@
 package cloud.eppo.android.dto;
 
+import com.google.gson.annotations.SerializedName;
+
 public class ShardRange {
     @SerializedName("start")
     private int start;

--- a/eppo/src/main/java/cloud/eppo/android/dto/ShardRange.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/ShardRange.java
@@ -1,7 +1,9 @@
 package cloud.eppo.android.dto;
 
 public class ShardRange {
+    @SerializedName("start")
     private int start;
+    @SerializedName("end")
     private int end;
 
     public int getStart() {

--- a/eppo/src/main/java/cloud/eppo/android/dto/TargetingCondition.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/TargetingCondition.java
@@ -1,5 +1,7 @@
 package cloud.eppo.android.dto;
 
+import com.google.gson.annotations.SerializedName;
+
 public class TargetingCondition {
     @SerializedName("operator")
     private String operator;

--- a/eppo/src/main/java/cloud/eppo/android/dto/TargetingCondition.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/TargetingCondition.java
@@ -1,8 +1,13 @@
 package cloud.eppo.android.dto;
 
 public class TargetingCondition {
+    @SerializedName("operator")
     private String operator;
+
+    @SerializedName("attribute")
     private String attribute;
+
+    @SerializedName("value")
     private EppoValue value;
 
     public OperatorType getOperator() {
@@ -29,4 +34,3 @@ public class TargetingCondition {
         this.value = value;
     }
 }
-

--- a/eppo/src/main/java/cloud/eppo/android/dto/TargetingRule.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/TargetingRule.java
@@ -3,7 +3,10 @@ package cloud.eppo.android.dto;
 import java.util.List;
 
 public class TargetingRule {
+    @SerializedName("allocationKey")
     private String allocationKey;
+
+    @SerializedName("conditions")
     private List<TargetingCondition> conditions;
 
     public String getAllocationKey() {

--- a/eppo/src/main/java/cloud/eppo/android/dto/TargetingRule.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/TargetingRule.java
@@ -1,7 +1,7 @@
 package cloud.eppo.android.dto;
 
 import java.util.List;
-
+import com.google.gson.annotations.SerializedName;
 public class TargetingRule {
     @SerializedName("allocationKey")
     private String allocationKey;

--- a/eppo/src/main/java/cloud/eppo/android/dto/Variation.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/Variation.java
@@ -1,5 +1,7 @@
 package cloud.eppo.android.dto;
 
+import com.google.gson.annotations.SerializedName;
+
 public class Variation {
     @SerializedName("typedValue")
     private EppoValue typedValue;

--- a/eppo/src/main/java/cloud/eppo/android/dto/Variation.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/Variation.java
@@ -1,7 +1,10 @@
 package cloud.eppo.android.dto;
 
 public class Variation {
+    @SerializedName("typedValue")
     private EppoValue typedValue;
+    
+    @SerializedName("shardRange")
     private ShardRange shardRange;
 
     public EppoValue getTypedValue() {


### PR DESCRIPTION
## problem

We had an observation from a customer that when they deployed the android SDK to production, while their testing environment behaved appropriated, they immediately saw crashes. 

Tracing through our application code we observed that the `flags` variable was being set to `null`, and then accessed casuing a`java.lang.NullPointerException`:

```
RandomizationConfigResponse config = gson.fromJson(response, RandomizationConfigResponse.class);
flags = config.getFlags();

flags.keySet() # exception!
```

Aaron has a PR (https://github.com/Eppo-exp/android-sdk/pull/38) to be more defensive.

👉 We verified that the response for the RAC API for this customer was well formed and valid.

## code change

My hypothesis for why `gson` is not able to deserialize the json payload into a Java object is because in the customer's production environment they are using Proguard, which obfuscates the Java code. The deserializer relies on the class attribute names matching the json fields exactly (or perhaps being snake case) but proguard could be wildly renamed them, such as `private float percentExposure -> private float a`, in which case `gson` can't perform the deserialization.

I am adding explicit json tag hints via `@SerializedName` so we can be independent of the class attribute name and we hope, resilient against Proguard changes.

This change might not make any improvement but it seems like its not a negative.
