### PR TITLE
Speed-up and de-flake our tests

### DIFF
--- a/.github/workflows/publish-sdk.yaml
+++ b/.github/workflows/publish-sdk.yaml
@@ -8,10 +8,10 @@ env:
 
 jobs:
   lint-test-sdk:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,12 +17,6 @@ jobs:
         with:
           repository: 'Eppo-exp/android-sdk'
 
-      - name: Enable KVM
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
@@ -59,6 +53,12 @@ jobs:
           done
           echo "Failed to resolve after 15 seconds"
           exit 1
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
         uses: gradle/actions/setup-gradle@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,10 +41,6 @@ jobs:
             ~/.android/adb*
           key: avd-33
 
-
-      - name: 'Set up GCP SDK'
-        uses: google-github-actions/setup-gcloud@v2
-
       - name: Restore gradle.properties
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,21 +10,40 @@ on:
 
 jobs:
   test-android-sdk:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Check out Java SDK
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'Eppo-exp/android-sdk'
 
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'adopt'
 
+      - name: Gradle cache
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: AVD cache
+        uses: actions/cache@v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-33
+
+
       - name: 'Set up GCP SDK'
-        uses: 'google-github-actions/setup-gcloud@v0'
+        uses: google-github-actions/setup-gcloud@v2
 
       - name: Restore gradle.properties
         env:
@@ -54,14 +73,25 @@ jobs:
           echo "Failed to resolve after 15 seconds"
           exit 1
 
+      - name: create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 33
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
       - name: Spin up emulator and run tests
         id: testing
         uses: ReactiveCircus/android-emulator-runner@v2
         with:
           api-level: 33
           target: google_apis
-          arch: x86_64
-          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -netdelay none -netspeed full -dns-server 8.8.8.8
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -netdelay none -netspeed full -dns-server 8.8.8.8
+          disable-animations: true
           script: |
             echo "Emulator started" 
             adb logcat -c                                     # clear logs

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,9 +21,6 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
 
-      - name: Set up test data
-        run: make test-data
-
       - name: Restore gradle.properties
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
@@ -34,6 +31,9 @@ jobs:
           echo "GRADLE_USER_HOME=${HOME}/.gradle" >> $GITHUB_ENV
           echo "MAVEN_USERNAME=${MAVEN_USERNAME}" > ~/.gradle/gradle.properties
           echo "MAVEN_PASSWORD=${MAVEN_PASSWORD}" >> ~/.gradle/gradle.properties
+
+      - name: Set up test data
+        run: make test-data
 
       - name: Wait for mock RAC DNS to resolve
         run: |
@@ -72,6 +72,8 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 33
+          target: google_apis
+          arch: x86_64
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
@@ -83,6 +85,7 @@ jobs:
         with:
           api-level: 33
           target: google_apis
+          arch: x86_64
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -netdelay none -netspeed full -dns-server 8.8.8.8
           disable-animations: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,17 +29,8 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
 
-      - name: Gradle cache
-        uses: gradle/actions/setup-gradle@v3
-
-      - name: AVD cache
-        uses: actions/cache@v4
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-33
+      - name: 'Set up GCP SDK'
+        uses: 'google-github-actions/setup-gcloud@v0'
 
       - name: Restore gradle.properties
         env:
@@ -68,6 +59,18 @@ jobs:
           done
           echo "Failed to resolve after 15 seconds"
           exit 1
+
+      - name: Gradle cache
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: AVD cache
+        uses: actions/cache@v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-33
 
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test-android-sdk:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Check out Java SDK
         uses: actions/checkout@v3
@@ -24,7 +24,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: 'adopt'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Java SDK
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           repository: 'Eppo-exp/android-sdk'
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,12 +10,10 @@ on:
 
 jobs:
   test-android-sdk:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Check out Java SDK
-        uses: actions/checkout@v3
-        with:
-          repository: 'Eppo-exp/android-sdk'
+        uses: actions/checkout@v4
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3
@@ -23,8 +21,8 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
 
-      - name: 'Set up GCP SDK'
-        uses: 'google-github-actions/setup-gcloud@v0'
+      - name: Set up test data
+        run: make test-data
 
       - name: Restore gradle.properties
         env:
@@ -36,9 +34,6 @@ jobs:
           echo "GRADLE_USER_HOME=${HOME}/.gradle" >> $GITHUB_ENV
           echo "MAVEN_USERNAME=${MAVEN_USERNAME}" > ~/.gradle/gradle.properties
           echo "MAVEN_PASSWORD=${MAVEN_PASSWORD}" >> ~/.gradle/gradle.properties
-
-      - name: Set up test data
-        run: make test-data
 
       - name: Wait for mock RAC DNS to resolve
         run: |

--- a/Makefile
+++ b/Makefile
@@ -34,12 +34,11 @@ githubRepoLink := https://github.com/Eppo-exp/sdk-test-data.git
 test-data: 
 	rm -rf $(testDataDir)
 	mkdir -p $(tempDir)
-	cd ${tempDir} \
-	    && git clone -b ${branchName} --depth 1 --single-branch ${githubRepoLink} \
-	    && rm -rf RepoName/.git/
-	cp ${gitDataDir}/rac-experiments-v3.json ${testDataDir}
-	cp ${gitDataDir}/rac-experiments-v3-hashed-keys.json ${testDataDir}
-	cp -r ${gitDataDir}/assignment-v2 ${testDataDir}
+	git clone -b ${branchName} --depth 1 --single-branch ${githubRepoLink} ${gitDataDir}
+	cp ${gitDataDir}rac-experiments-v3.json ${testDataDir}
+	cp ${gitDataDir}rac-experiments-v3-obfuscated.json ${testDataDir}
+	cp -r ${gitDataDir}assignment-v2 ${testDataDir}
+	cp -r ${gitDataDir}assignment-v2-holdouts/. ${testDataDir}assignment-v2
 	rm -rf ${tempDir}
 
 ## test

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@ test-data:
 	rm -rf $(testDataDir)
 	mkdir -p $(tempDir)
 	git clone -b ${branchName} --depth 1 --single-branch ${githubRepoLink} ${gitDataDir}
-	cp ${gitDataDir}rac-experiments-v3.json ${testDataDir}
-	cp ${gitDataDir}rac-experiments-v3-obfuscated.json ${testDataDir}
-	cp -r ${gitDataDir}assignment-v2 ${testDataDir}
-	cp -r ${gitDataDir}assignment-v2-holdouts/. ${testDataDir}assignment-v2
+	cp ${gitDataDir}/rac-experiments-v3.json ${testDataDir}
+	cp ${gitDataDir}/rac-experiments-v3-obfuscated.json ${testDataDir}
+	cp -r ${gitDataDir}/assignment-v2 ${testDataDir}
+	cp -r ${gitDataDir}/assignment-v2-holdouts/. ${testDataDir}/assignment-v2
 	rm -rf ${tempDir}
 
 ## test

--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,8 @@ test-data:
 	mkdir -p $(tempDir)
 	git clone -b ${branchName} --depth 1 --single-branch ${githubRepoLink} ${gitDataDir}
 	cp ${gitDataDir}/rac-experiments-v3.json ${testDataDir}
-	cp ${gitDataDir}/rac-experiments-v3-obfuscated.json ${testDataDir}
+	cp ${gitDataDir}/rac-experiments-v3-hashed-keys.json ${testDataDir}
 	cp -r ${gitDataDir}/assignment-v2 ${testDataDir}
-	cp -r ${gitDataDir}/assignment-v2-holdouts/. ${testDataDir}/assignment-v2
 	rm -rf ${tempDir}
 
 ## test

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -452,27 +452,6 @@ public class EppoClientTest {
         }
     }
 
-    // TODO: useful?
-    private void waitForSharedPreferences() {
-        long waitStart = System.currentTimeMillis();
-        long waitEnd = waitStart + 5 * 1000; // allow up to 5 seconds
-        boolean sharedPrefsReady = false;
-        try {
-            while (!sharedPrefsReady) {
-                if (System.currentTimeMillis() > waitEnd) {
-                    throw new InterruptedException("Shared preferences never ready");
-                }
-                SharedPreferences sharedPreferences = ApplicationProvider.getApplicationContext().getSharedPreferences("eppo", Context.MODE_PRIVATE);
-                sharedPrefsReady = !sharedPreferences.getAll().isEmpty();
-                if (!sharedPrefsReady) {
-                    Thread.sleep(100);
-                }
-            }
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     private void waitForNonNullAssignment() {
         long waitStart = System.currentTimeMillis();
         long waitEnd = waitStart + 15 * 1000; // allow up to 15 seconds

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -265,8 +265,7 @@ public class EppoClientTest {
             initClient(TEST_HOST, false, true, false); // ensure cache is populated
 
             // wait for a bit since cache file is loaded asynchronously
-            System.out.println("Sleeping for a bit to wait for cache population to complete");
-            Thread.sleep(10000);
+            waitForPopulatedCache();
 
             // Then reinitialize with a bad host so we know it's using the cached RAC built from the first initialization
             initClient(INVALID_HOST, false, false, false); // invalid port to force to use cache
@@ -428,6 +427,27 @@ public class EppoClientTest {
         assertEquals("control", assignment);
     }
 
+    private void waitForPopulatedCache() {
+        long waitStart = System.currentTimeMillis();
+        long waitEnd = waitStart + 10 * 1000; // allow up to 10 seconds
+        boolean cachePopulated = false;
+        try {
+            File file = new File(ApplicationProvider.getApplicationContext().getFilesDir(), CACHE_FILE_NAME);
+            while (!cachePopulated) {
+                if (System.currentTimeMillis() > waitEnd) {
+                    throw new InterruptedException("Cache file never populated; assuming configuration error");
+                }
+                long expectedMinimumSizeInBytes = 4000; // At time of writing cache size is 4354
+                cachePopulated = file.exists() && file.length() > expectedMinimumSizeInBytes;
+                if (!cachePopulated) {
+                    Thread.sleep(100);
+                }
+            }
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     private void waitForNonNullAssignment() {
         long waitStart = System.currentTimeMillis();
         long waitEnd = waitStart + 15 * 1000; // allow up to 15 seconds
@@ -439,7 +459,9 @@ public class EppoClientTest {
                 }
                 // Uses third subject in test-case-0
                 assignment = EppoClient.getInstance().getStringAssignment("6255e1a7fc33a9c050ce9508", "randomization_algo");
-                Thread.sleep(100);
+                if (assignment == null) {
+                    Thread.sleep(100);
+                }
             }
         } catch (InterruptedException e) {
             throw new RuntimeException(e);

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -7,6 +7,8 @@ import static org.junit.Assert.assertTrue;
 
 import static cloud.eppo.android.ConfigCacheFile.CACHE_FILE_NAME;
 
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.res.AssetManager;
 
 import androidx.test.core.app.ApplicationProvider;
@@ -129,6 +131,8 @@ public class EppoClientTest {
 
     private void deleteCacheFiles() {
         deleteFileIfExists(CACHE_FILE_NAME);
+        SharedPreferences sharedPreferences = ApplicationProvider.getApplicationContext().getSharedPreferences("eppo", Context.MODE_PRIVATE);
+        sharedPreferences.edit().clear().commit();
     }
 
     private void initClient(String host, boolean throwOnCallackError, boolean shouldDeleteCacheFiles, boolean isGracefulMode)
@@ -440,6 +444,27 @@ public class EppoClientTest {
                 long expectedMinimumSizeInBytes = 4000; // At time of writing cache size is 4354
                 cachePopulated = file.exists() && file.length() > expectedMinimumSizeInBytes;
                 if (!cachePopulated) {
+                    Thread.sleep(100);
+                }
+            }
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // TODO: useful?
+    private void waitForSharedPreferences() {
+        long waitStart = System.currentTimeMillis();
+        long waitEnd = waitStart + 5 * 1000; // allow up to 5 seconds
+        boolean sharedPrefsReady = false;
+        try {
+            while (!sharedPrefsReady) {
+                if (System.currentTimeMillis() > waitEnd) {
+                    throw new InterruptedException("Shared preferences never ready");
+                }
+                SharedPreferences sharedPreferences = ApplicationProvider.getApplicationContext().getSharedPreferences("eppo", Context.MODE_PRIVATE);
+                sharedPrefsReady = !sharedPreferences.getAll().isEmpty();
+                if (!sharedPrefsReady) {
                     Thread.sleep(100);
                 }
             }

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
@@ -102,7 +102,7 @@ public class ConfigurationStore {
                 String hashedFlagKey = Utils.getMD5Hex(plaintextFlagKey);
                 writeFlagToSharedPrefs(hashedFlagKey, flagConfig, editor);
             }
-            editor.commit();
+            editor.apply();
             flagConfigsToSaveToPrefs.clear();
         }
 
@@ -116,7 +116,7 @@ public class ConfigurationStore {
                 writeFlagToSharedPrefs(hashedFlagKey, flags.get(hashedFlagKey), editor);
             }
         }
-        editor.commit();
+        editor.apply();
     }
 
     private void writeFlagToSharedPrefs(String hashedFlagKey, FlagConfig config, SharedPreferences.Editor editor) {

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
@@ -61,6 +61,7 @@ public class ConfigurationStore {
                         throw new JsonSyntaxException("Configuration file missing flags");
                     }
                     flags = configResponse.getFlags();
+                    updateConfigsInSharedPrefs();
                 }
                 Log.d(TAG, "Cache loaded successfully");
             } catch (Exception e) {

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
@@ -102,7 +102,7 @@ public class ConfigurationStore {
                 String hashedFlagKey = Utils.getMD5Hex(plaintextFlagKey);
                 writeFlagToSharedPrefs(hashedFlagKey, flagConfig, editor);
             }
-            editor.apply();
+            editor.commit();
             flagConfigsToSaveToPrefs.clear();
         }
 
@@ -116,7 +116,7 @@ public class ConfigurationStore {
                 writeFlagToSharedPrefs(hashedFlagKey, flags.get(hashedFlagKey), editor);
             }
         }
-        editor.apply();
+        editor.commit();
     }
 
     private void writeFlagToSharedPrefs(String hashedFlagKey, FlagConfig config, SharedPreferences.Editor editor) {


### PR DESCRIPTION
To speed up these tests, I followed the suggestions in the [emulator runner action](https://github.com/marketplace/actions/android-emulator-runner) we use. It mainly said to use Ubuntu, enable acceleration, and try to cache Gradle and the Image.

To de-flake, I now clear SharedPreferences between tests (if we blow away the file cache too). My suspicion is that we were storing a bad (perhaps mocked) config in there that would mess up a later test until it fetched an updated config.

🔥 🔥 🔥 🔥 🔥 🔥 
![image](https://github.com/Eppo-exp/android-sdk/assets/417605/e9ca4048-5e83-46dc-8651-611e2a874c6b)