### PR TITLE
Handle being able to be minified by ProGuard

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,7 +65,7 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-33
+          key: avd-api-33-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
 
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
 
 import cloud.eppo.android.dto.EppoValue;
 import cloud.eppo.android.dto.SubjectAttributes;
-import cloud.eppo.android.dto.adapters.EppoValueAdapter;
+import cloud.eppo.android.dto.deserializers.EppoValueAdapter;
 
 public class EppoClientTest {
     private static final String TAG = logTag(EppoClient.class);

--- a/eppo/src/main/java/cloud/eppo/android/CacheLoadCallback.java
+++ b/eppo/src/main/java/cloud/eppo/android/CacheLoadCallback.java
@@ -1,0 +1,7 @@
+package cloud.eppo.android;
+
+public interface CacheLoadCallback {
+    void onCacheLoadSuccess();
+
+    void onCacheLoadFail();
+}

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
@@ -21,7 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import cloud.eppo.android.dto.EppoValue;
 import cloud.eppo.android.dto.FlagConfig;
 import cloud.eppo.android.dto.RandomizationConfigResponse;
-import cloud.eppo.android.dto.adapters.EppoValueAdapter;
+import cloud.eppo.android.dto.deserializers.EppoValueAdapter;
 import cloud.eppo.android.dto.deserializers.RandomizationConfigResponseDeserializer;
 import cloud.eppo.android.util.Utils;
 

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
@@ -22,6 +22,7 @@ import cloud.eppo.android.dto.EppoValue;
 import cloud.eppo.android.dto.FlagConfig;
 import cloud.eppo.android.dto.RandomizationConfigResponse;
 import cloud.eppo.android.dto.adapters.EppoValueAdapter;
+import cloud.eppo.android.dto.deserializers.RandomizationConfigResponseDeserializer;
 import cloud.eppo.android.util.Utils;
 
 public class ConfigurationStore {
@@ -29,6 +30,7 @@ public class ConfigurationStore {
     private static final String TAG = logTag(ConfigurationStore.class);
 
     private final Gson gson = new GsonBuilder()
+            .registerTypeAdapter(RandomizationConfigResponse.class, new RandomizationConfigResponseDeserializer())
             .registerTypeAdapter(EppoValue.class, new EppoValueAdapter())
             .serializeNulls()
             .create();
@@ -43,10 +45,11 @@ public class ConfigurationStore {
         this.sharedPrefs = Utils.getSharedPrefs(application);
     }
 
-    public boolean loadFromCache(InitializationCallback callback) {
+    public void loadFromCache(CacheLoadCallback callback) {
         if (flags != null || !cacheFile.exists()) {
             Log.d(TAG, "Not loading from cache ("+(flags == null ? "null flags" : "non-null flags")+")");
-            return false;
+            callback.onCacheLoadFail();
+            return;
         }
 
         AsyncTask.execute(() -> {
@@ -57,35 +60,28 @@ public class ConfigurationStore {
                     RandomizationConfigResponse configResponse = gson.fromJson(reader, RandomizationConfigResponse.class);
                     reader.close();
                     if (configResponse == null || configResponse.getFlags() == null) {
-                        // Invalid cached configuration, initialize as an empty map and delete file
                         throw new JsonSyntaxException("Configuration file missing flags");
                     }
                     flags = configResponse.getFlags();
                     updateConfigsInSharedPrefs();
                 }
                 Log.d(TAG, "Cache loaded successfully");
+                callback.onCacheLoadSuccess();
             } catch (Exception e) {
                 Log.e(TAG, "Error loading from local cache", e);
                 cacheFile.delete();
-
-                if (callback != null) {
-                    callback.onError("Unable to load config from cache");
-                }
-            }
-
-            if (callback != null) {
-                callback.onCompleted();
+                callback.onCacheLoadFail();
             }
         });
-        return true;
     }
 
     public void setFlags(Reader response) {
         RandomizationConfigResponse config = gson.fromJson(response, RandomizationConfigResponse.class);
-        flags = config.getFlags();
-        if (flags == null) {
+        if (config == null || config.getFlags() == null) {
             Log.w(TAG, "Flags missing in configuration response");
             flags = new ConcurrentHashMap<>();
+        } else {
+            flags = config.getFlags();
         }
 
         // update any existing flags already in shared prefs

--- a/eppo/src/main/java/cloud/eppo/android/dto/Allocation.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/Allocation.java
@@ -1,17 +1,22 @@
 package cloud.eppo.android.dto;
 
 import java.util.List;
-import com.google.gson.annotations.SerializedName;
 
 public class Allocation {
-    @SerializedName("percentExposure")
     private float percentExposure;
 
-    @SerializedName("variations")
     private List<Variation> variations;
+
+    public void setPercentExposure(float percentExposure) {
+        this.percentExposure = percentExposure;
+    }
 
     public float getPercentExposure() {
         return percentExposure;
+    }
+
+    public void setVariations(List<Variation> variations) {
+        this.variations = variations;
     }
 
     public List<Variation> getVariations() {

--- a/eppo/src/main/java/cloud/eppo/android/dto/Allocation.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/Allocation.java
@@ -7,19 +7,19 @@ public class Allocation {
 
     private List<Variation> variations;
 
-    public void setPercentExposure(float percentExposure) {
-        this.percentExposure = percentExposure;
-    }
-
     public float getPercentExposure() {
         return percentExposure;
     }
 
-    public void setVariations(List<Variation> variations) {
-        this.variations = variations;
+    public void setPercentExposure(float percentExposure) {
+        this.percentExposure = percentExposure;
     }
 
     public List<Variation> getVariations() {
         return variations;
+    }
+
+    public void setVariations(List<Variation> variations) {
+        this.variations = variations;
     }
 }

--- a/eppo/src/main/java/cloud/eppo/android/dto/FlagConfig.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/FlagConfig.java
@@ -1,7 +1,5 @@
 package cloud.eppo.android.dto;
 
-import com.google.gson.annotations.SerializedName;
-
 import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
@@ -17,40 +15,43 @@ public class FlagConfig {
 
     private Map<String, Allocation> allocations;
 
+    public int getSubjectShards() {
+        return subjectShards;
+    }
+
     public void setSubjectShards(int subjectShards) {
         this.subjectShards = subjectShards;
     }
-    public int getSubjectShards() {
-        return subjectShards;
+
+    public boolean isEnabled() {
+        return enabled;
     }
 
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
     }
-    public boolean isEnabled() {
-        return enabled;
-    }
 
-    public void setTypedOverrides(Map<String, String> typedOverrides) {
-        this.typedOverrides = typedOverrides;
-    }
     public Map<String, String> getTypedOverrides() {
         return typedOverrides;
     }
 
-    public  void setAllocations(Map<String, Allocation> allocations) {
-        this.allocations = allocations;
+    public void setTypedOverrides(Map<String, String> typedOverrides) {
+        this.typedOverrides = typedOverrides;
     }
 
     public Map<String, Allocation> getAllocations() {
         return allocations;
     }
 
-    public void setRules(List<TargetingRule> rules) {
-        this.rules = rules;
+    public  void setAllocations(Map<String, Allocation> allocations) {
+        this.allocations = allocations;
     }
 
     public List<TargetingRule> getRules() {
         return rules;
+    }
+
+    public void setRules(List<TargetingRule> rules) {
+        this.rules = rules;
     }
 }

--- a/eppo/src/main/java/cloud/eppo/android/dto/FlagConfig.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/FlagConfig.java
@@ -7,35 +7,47 @@ import java.util.Map;
 import java.util.HashMap;
 
 public class FlagConfig {
-    @SerializedName("subjectShards")
     private int subjectShards;
 
-    @SerializedName("enabled")
     private boolean enabled;
 
-    @SerializedName("typedOverrides")
     private Map<String, String> typedOverrides = new HashMap<>();
 
-    @SerializedName("rules")
     private List<TargetingRule> rules;
 
-    @SerializedName("allocations")
     private Map<String, Allocation> allocations;
 
+    public void setSubjectShards(int subjectShards) {
+        this.subjectShards = subjectShards;
+    }
     public int getSubjectShards() {
         return subjectShards;
     }
 
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
     public boolean isEnabled() {
         return enabled;
     }
 
+    public void setTypedOverrides(Map<String, String> typedOverrides) {
+        this.typedOverrides = typedOverrides;
+    }
     public Map<String, String> getTypedOverrides() {
         return typedOverrides;
     }
 
+    public  void setAllocations(Map<String, Allocation> allocations) {
+        this.allocations = allocations;
+    }
+
     public Map<String, Allocation> getAllocations() {
         return allocations;
+    }
+
+    public void setRules(List<TargetingRule> rules) {
+        this.rules = rules;
     }
 
     public List<TargetingRule> getRules() {

--- a/eppo/src/main/java/cloud/eppo/android/dto/OperatorType.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/OperatorType.java
@@ -15,8 +15,6 @@ public enum OperatorType {
         this.value = value;
     }
 
-
-    // TODO: does this work with obfuscation?
     public static OperatorType fromString(String value) {
         for (OperatorType type : OperatorType.values()) {
             if (type.value.equals(value)) {

--- a/eppo/src/main/java/cloud/eppo/android/dto/OperatorType.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/OperatorType.java
@@ -15,6 +15,8 @@ public enum OperatorType {
         this.value = value;
     }
 
+
+    // TODO: does this work with obfuscation?
     public static OperatorType fromString(String value) {
         for (OperatorType type : OperatorType.values()) {
             if (type.value.equals(value)) {

--- a/eppo/src/main/java/cloud/eppo/android/dto/RandomizationConfigResponse.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/RandomizationConfigResponse.java
@@ -5,11 +5,11 @@ import java.util.concurrent.ConcurrentHashMap;
 public class RandomizationConfigResponse {
     private ConcurrentHashMap<String, FlagConfig> flags;
 
-    public void setFlags(ConcurrentHashMap<String, FlagConfig> flags) {
-        this.flags = flags;
-    }
-
     public ConcurrentHashMap<String, FlagConfig> getFlags() {
         return flags;
+    }
+
+    public void setFlags(ConcurrentHashMap<String, FlagConfig> flags) {
+        this.flags = flags;
     }
 }

--- a/eppo/src/main/java/cloud/eppo/android/dto/RandomizationConfigResponse.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/RandomizationConfigResponse.java
@@ -1,11 +1,13 @@
 package cloud.eppo.android.dto;
 
 import java.util.concurrent.ConcurrentHashMap;
-import com.google.gson.annotations.SerializedName;
 
 public class RandomizationConfigResponse {
-    @SerializedName("flags")
     private ConcurrentHashMap<String, FlagConfig> flags;
+
+    public void setFlags(ConcurrentHashMap<String, FlagConfig> flags) {
+        this.flags = flags;
+    }
 
     public ConcurrentHashMap<String, FlagConfig> getFlags() {
         return flags;

--- a/eppo/src/main/java/cloud/eppo/android/dto/ShardRange.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/ShardRange.java
@@ -12,12 +12,12 @@ public class ShardRange {
         return start;
     }
 
-    public int getEnd() {
-        return end;
-    }
-
     public void setStart(int start) {
         this.start = start;
+    }
+
+    public int getEnd() {
+        return end;
     }
 
     public void setEnd(int end) {

--- a/eppo/src/main/java/cloud/eppo/android/dto/ShardRange.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/ShardRange.java
@@ -1,11 +1,7 @@
 package cloud.eppo.android.dto;
 
-import com.google.gson.annotations.SerializedName;
-
 public class ShardRange {
-    @SerializedName("start")
     private int start;
-    @SerializedName("end")
     private int end;
 
     public int getStart() {

--- a/eppo/src/main/java/cloud/eppo/android/dto/TargetingCondition.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/TargetingCondition.java
@@ -1,7 +1,5 @@
 package cloud.eppo.android.dto;
 
-import com.google.gson.annotations.SerializedName;
-
 public class TargetingCondition {
     private String operator;
 

--- a/eppo/src/main/java/cloud/eppo/android/dto/TargetingCondition.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/TargetingCondition.java
@@ -3,33 +3,30 @@ package cloud.eppo.android.dto;
 import com.google.gson.annotations.SerializedName;
 
 public class TargetingCondition {
-    @SerializedName("operator")
     private String operator;
 
-    @SerializedName("attribute")
     private String attribute;
 
-    @SerializedName("value")
     private EppoValue value;
 
     public OperatorType getOperator() {
         return OperatorType.fromString(operator);
     }
 
-    public String getAttribute() {
-        return attribute;
-    }
-
-    public EppoValue getValue() {
-        return value;
-    }
-
     public void setOperator(OperatorType operatorType) {
         this.operator = operatorType.value;
     }
 
+    public String getAttribute() {
+        return attribute;
+    }
+
     public void setAttribute(String attribute) {
         this.attribute = attribute;
+    }
+
+    public EppoValue getValue() {
+        return value;
     }
 
     public void setValue(EppoValue value) {

--- a/eppo/src/main/java/cloud/eppo/android/dto/TargetingRule.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/TargetingRule.java
@@ -24,6 +24,4 @@ public class TargetingRule {
     public void setConditions(List<TargetingCondition> conditions) {
         this.conditions = conditions;
     }
-
-
 }

--- a/eppo/src/main/java/cloud/eppo/android/dto/TargetingRule.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/TargetingRule.java
@@ -13,6 +13,10 @@ public class TargetingRule {
         return allocationKey;
     }
 
+    public void setAllocationKey(String allocationKey) {
+        this.allocationKey = allocationKey;
+    }
+
     public List<TargetingCondition> getConditions() {
         return conditions;
     }
@@ -20,4 +24,6 @@ public class TargetingRule {
     public void setConditions(List<TargetingCondition> conditions) {
         this.conditions = conditions;
     }
+
+
 }

--- a/eppo/src/main/java/cloud/eppo/android/dto/TargetingRule.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/TargetingRule.java
@@ -1,12 +1,10 @@
 package cloud.eppo.android.dto;
 
 import java.util.List;
-import com.google.gson.annotations.SerializedName;
+
 public class TargetingRule {
-    @SerializedName("allocationKey")
     private String allocationKey;
 
-    @SerializedName("conditions")
     private List<TargetingCondition> conditions;
 
     public String getAllocationKey() {

--- a/eppo/src/main/java/cloud/eppo/android/dto/Variation.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/Variation.java
@@ -3,14 +3,20 @@ package cloud.eppo.android.dto;
 import com.google.gson.annotations.SerializedName;
 
 public class Variation {
-    @SerializedName("typedValue")
     private EppoValue typedValue;
-    
-    @SerializedName("shardRange")
+
     private ShardRange shardRange;
+
+    public void setTypedValue(EppoValue typedValue) {
+        this.typedValue = typedValue;
+    }
 
     public EppoValue getTypedValue() {
         return typedValue;
+    }
+
+    public void setShardRange(ShardRange shardRange) {
+        this.shardRange = shardRange;
     }
 
     public ShardRange getShardRange() {

--- a/eppo/src/main/java/cloud/eppo/android/dto/Variation.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/Variation.java
@@ -1,7 +1,5 @@
 package cloud.eppo.android.dto;
 
-import com.google.gson.annotations.SerializedName;
-
 public class Variation {
     private EppoValue typedValue;
 

--- a/eppo/src/main/java/cloud/eppo/android/dto/Variation.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/Variation.java
@@ -7,19 +7,19 @@ public class Variation {
 
     private ShardRange shardRange;
 
-    public void setTypedValue(EppoValue typedValue) {
-        this.typedValue = typedValue;
-    }
-
     public EppoValue getTypedValue() {
         return typedValue;
     }
 
-    public void setShardRange(ShardRange shardRange) {
-        this.shardRange = shardRange;
+    public void setTypedValue(EppoValue typedValue) {
+        this.typedValue = typedValue;
     }
 
     public ShardRange getShardRange() {
         return shardRange;
+    }
+
+    public void setShardRange(ShardRange shardRange) {
+        this.shardRange = shardRange;
     }
 }

--- a/eppo/src/main/java/cloud/eppo/android/dto/deserializers/EppoValueAdapter.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/deserializers/EppoValueAdapter.java
@@ -1,4 +1,4 @@
-package cloud.eppo.android.dto.adapters;
+package cloud.eppo.android.dto.deserializers;
 
 import static cloud.eppo.android.util.Utils.logTag;
 

--- a/eppo/src/main/java/cloud/eppo/android/dto/deserializers/RandomizationConfigResponseDeserializer.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/deserializers/RandomizationConfigResponseDeserializer.java
@@ -4,13 +4,11 @@ import static cloud.eppo.android.util.Utils.logTag;
 
 import android.util.Log;
 
-import com.google.gson.JsonArray;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
-import com.google.gson.JsonPrimitive;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -33,8 +31,8 @@ import cloud.eppo.android.dto.adapters.EppoValueAdapter;
 
 /**
  *  Hand-rolled deserializer so that we don't rely on annotations and method names, which can be
- *  unreliable when ProGuard minification is in-use and not configured to protect JSON-related
- *  classes.
+ *  unreliable when ProGuard minification is in-use and not configured to protect
+ *  JSON-deserialization-related classes and annotations.
  */
 public class RandomizationConfigResponseDeserializer implements JsonDeserializer<RandomizationConfigResponse> {
     private static final String TAG = logTag(EppoClient.class);
@@ -45,132 +43,153 @@ public class RandomizationConfigResponseDeserializer implements JsonDeserializer
     public RandomizationConfigResponse deserialize(JsonElement rootElement, Type type, JsonDeserializationContext context) throws JsonParseException {
         ConcurrentHashMap<String, FlagConfig> flags = new ConcurrentHashMap<>();
         RandomizationConfigResponse configResponse = new RandomizationConfigResponse();
-        configResponse.setFlags(flags);
+        configResponse.setFlags(flags); // Default to a response with an empty map of flags
+
         if (rootElement == null || !rootElement.isJsonObject()) {
             Log.w(TAG, "no top-level JSON object");
             return configResponse;
         }
+
         JsonObject rootObject = rootElement.getAsJsonObject();
         JsonElement flagsElement = rootObject.get("flags");
         if (flagsElement == null) {
             Log.w(TAG, "no root-level flags property");
             return configResponse;
         }
+
         JsonObject flagsObject = flagsElement.getAsJsonObject();
         for (Map.Entry<String, JsonElement> flagEntry : flagsObject.entrySet()) {
             String flagKey = flagEntry.getKey();
-            JsonObject flagObject = flagEntry.getValue().getAsJsonObject();
-            int subjectShards = flagObject.get("subjectShards").getAsInt();
-            boolean enabled = flagObject.get("enabled").getAsBoolean();
-
-            Map<String, String> typedOverrides = new HashMap<>();
-            JsonElement typedOverridesElement = flagObject.get("typedOverrides");
-            if (typedOverridesElement != null) {
-                for (Map.Entry<String, JsonElement> typedOverridesEntry : typedOverridesElement.getAsJsonObject().entrySet()) {
-                    typedOverrides.put(typedOverridesEntry.getKey(), typedOverridesEntry.getValue().getAsString());
-
-                }
-            }
-
-            Map<String, Allocation> allocations = new HashMap<>();
-            JsonObject allocationsObject = flagObject.get("allocations").getAsJsonObject();
-            for (Map.Entry<String, JsonElement> allocationEntry : allocationsObject.entrySet()) {
-                String allocationKey = allocationEntry.getKey();
-                JsonObject allocationObject = allocationEntry.getValue().getAsJsonObject();
-                float percentExposure = allocationObject.get("percentExposure").getAsFloat();
-                JsonArray variationsArray = allocationObject.get("variations").getAsJsonArray();
-                List<Variation> variations = new ArrayList<>();
-                for (JsonElement variationElement : variationsArray) {
-                    JsonObject variationObject = variationElement.getAsJsonObject();
-
-                    JsonObject shardRangeObject = variationObject.get("shardRange").getAsJsonObject();
-                    int shardRangeStart = shardRangeObject.get("start").getAsInt();
-                    int shardRangeEnd = shardRangeObject.get("end").getAsInt();
-                    ShardRange shardRange = new ShardRange();
-                    shardRange.setStart(shardRangeStart);
-                    shardRange.setEnd(shardRangeEnd);
-
-                    EppoValue typedValue = eppoValueAdapter.deserialize(variationObject.get("typedValue"), type, context);
-
-                    Variation variation = new Variation();
-                    variation.setShardRange(shardRange);
-                    variation.setTypedValue(typedValue);
-                    variations.add(variation);
-                }
-
-                Allocation allocation = new Allocation();
-                allocation.setPercentExposure(percentExposure);
-                allocation.setVariations(variations);
-                allocations.put(allocationKey, allocation);
-            }
-
-            List<TargetingRule> targetingRules = new ArrayList<>();
-            for (JsonElement ruleElement : flagObject.getAsJsonArray("rules").getAsJsonArray()) {
-                JsonObject rulesObject = ruleElement.getAsJsonObject();
-                String allocationKey = rulesObject.get("allocationKey").getAsString();
-
-                List<TargetingCondition> conditions = new ArrayList<>();
-                for (JsonElement conditionElement : rulesObject.get("conditions").getAsJsonArray()) {
-                    JsonObject conditionObject = conditionElement.getAsJsonObject();
-                    String attribute = conditionObject.get("attribute").getAsString();
-                    OperatorType operator = OperatorType.fromString(conditionObject.get("operator").getAsString());
-                    EppoValue value = eppoValueAdapter.deserialize(conditionObject.get("value"), type, context);
-
-                    TargetingCondition condition = new TargetingCondition();
-                    condition.setAttribute(attribute);
-                    condition.setOperator(operator);
-                    condition.setValue(value);
-                    conditions.add(condition);
-                }
-
-                TargetingRule targetingRule = new TargetingRule();
-                targetingRule.setAllocationKey(allocationKey);
-                targetingRule.setConditions(conditions);
-                targetingRules.add(targetingRule);
-            }
-
-            FlagConfig flagConfig = new FlagConfig();
-            flagConfig.setEnabled(enabled);
-            flagConfig.setSubjectShards(subjectShards);
-            flagConfig.setTypedOverrides(typedOverrides);
-            flagConfig.setAllocations(allocations);
-            flagConfig.setRules(targetingRules);
+            FlagConfig flagConfig = deserializeFlag(flagEntry.getValue(), type, context);
             flags.put(flagKey, flagConfig);
         }
 
         return configResponse;
     }
 
-    private EppoValue deserializeToEppoValue(JsonElement element) {
-        EppoValue typedValue = EppoValue.valueOf(); // Default to null
-        if (element == null) {
-            return typedValue;
+    private FlagConfig deserializeFlag(JsonElement jsonElement, Type type, JsonDeserializationContext context) {
+        JsonObject flagObject = jsonElement.getAsJsonObject();
+        int subjectShards = flagObject.get("subjectShards").getAsInt();
+        boolean enabled = flagObject.get("enabled").getAsBoolean();
+        Map<String, String> typedOverrides = deserializeTypedOverrides(flagObject.get("typedOverrides"));
+        List<TargetingRule> rules = deserializeTargetingRules(flagObject.get("rules"), type, context);
+        Map<String, Allocation> allocations = deserializeAllocations(flagObject.get("allocations"), type, context);
+
+        FlagConfig flagConfig = new FlagConfig();
+        flagConfig.setEnabled(enabled);
+        flagConfig.setSubjectShards(subjectShards);
+        flagConfig.setTypedOverrides(typedOverrides);
+        flagConfig.setRules(rules);
+        flagConfig.setAllocations(allocations);
+        return flagConfig;
+    }
+
+    private Map<String, String> deserializeTypedOverrides(JsonElement jsonElement) {
+        Map<String, String> typedOverrides = new HashMap<>();
+        if (jsonElement == null) {
+            return typedOverrides;
         }
 
-        if (element.isJsonPrimitive()) {
-            JsonPrimitive primitive = element.getAsJsonPrimitive();
-            if (primitive.isBoolean()) {
-                typedValue = EppoValue.valueOf(primitive.getAsBoolean());
-            } else if (primitive.isNumber()) {
-                typedValue = EppoValue.valueOf(primitive.getAsDouble());
-            } else {
-                String stringPrimitive = primitive.getAsString();
-                if (stringPrimitive == "null") {
-                    // TODO: do we want to keep doing this?
-                } else {
-                    typedValue = EppoValue.valueOf();
-                }
-            }
-        } else if (element.isJsonArray()){
-            ArrayList<String> valueArray = new ArrayList<>();
-            for (JsonElement arrayElement : element.getAsJsonArray()) {
-                valueArray.add(arrayElement.getAsString());
-            }
-            typedValue = EppoValue.valueOf(valueArray);
-        } else if (element.isJsonObject()) {
-            typedValue = EppoValue.valueOf(element);
+        for (Map.Entry<String, JsonElement> typedOverridesEntry : jsonElement.getAsJsonObject().entrySet()) {
+            typedOverrides.put(typedOverridesEntry.getKey(), typedOverridesEntry.getValue().getAsString());
+
         }
 
-        return typedValue;
+        return typedOverrides;
+    }
+
+    private List<TargetingRule> deserializeTargetingRules(JsonElement jsonElement, Type type, JsonDeserializationContext context) {
+        List<TargetingRule> targetingRules = new ArrayList<>();
+        if (jsonElement == null) {
+            return targetingRules;
+        }
+
+        for (JsonElement ruleElement : jsonElement.getAsJsonArray()) {
+            JsonObject rulesObject = ruleElement.getAsJsonObject();
+            String allocationKey = rulesObject.get("allocationKey").getAsString();
+            List<TargetingCondition> conditions = deserializeTargetingCondition(rulesObject.get("conditions"), type, context);
+
+            TargetingRule targetingRule = new TargetingRule();
+            targetingRule.setAllocationKey(allocationKey);
+            targetingRule.setConditions(conditions);
+            targetingRules.add(targetingRule);
+        }
+
+        return targetingRules;
+    }
+
+    private List<TargetingCondition> deserializeTargetingCondition(JsonElement jsonElement, Type type, JsonDeserializationContext context) {
+        List<TargetingCondition> conditions = new ArrayList<>();
+        if (jsonElement == null) {
+            return conditions;
+        }
+
+        for (JsonElement conditionElement : jsonElement.getAsJsonArray()) {
+            JsonObject conditionObject = conditionElement.getAsJsonObject();
+            String attribute = conditionObject.get("attribute").getAsString();
+            String operatorKey = conditionObject.get("operator").getAsString();
+            OperatorType operator = OperatorType.fromString(operatorKey);
+            if (operator == null) {
+                Log.w(TAG, "Unknown operator \""+operatorKey+"\"");
+                continue;
+            }
+            EppoValue value = eppoValueAdapter.deserialize(conditionObject.get("value"), type, context);
+
+            TargetingCondition condition = new TargetingCondition();
+            condition.setAttribute(attribute);
+            condition.setOperator(operator);
+            condition.setValue(value);
+            conditions.add(condition);
+        }
+
+        return conditions;
+    }
+
+    private Map<String, Allocation> deserializeAllocations(JsonElement jsonElement, Type type, JsonDeserializationContext context) {
+        Map<String, Allocation> allocations = new HashMap<>();
+        if (jsonElement == null) {
+            return allocations;
+        }
+
+        for (Map.Entry<String, JsonElement> allocationEntry : jsonElement.getAsJsonObject().entrySet()) {
+            String allocationKey = allocationEntry.getKey();
+            JsonObject allocationObject = allocationEntry.getValue().getAsJsonObject();
+            float percentExposure = allocationObject.get("percentExposure").getAsFloat();
+            List<Variation> variations = deserializeVariations(allocationObject.get("variations"), type, context);
+
+            Allocation allocation = new Allocation();
+            allocation.setPercentExposure(percentExposure);
+            allocation.setVariations(variations);
+            allocations.put(allocationKey, allocation);
+        }
+
+        return allocations;
+    }
+
+    private List<Variation> deserializeVariations(JsonElement jsonElement, Type type, JsonDeserializationContext context) {
+        List<Variation> variations = new ArrayList<>();
+        if (jsonElement == null) {
+            return variations;
+        }
+
+        for (JsonElement variationElement : jsonElement.getAsJsonArray()) {
+            JsonObject variationObject = variationElement.getAsJsonObject();
+
+            JsonObject shardRangeObject = variationObject.get("shardRange").getAsJsonObject();
+            int shardRangeStart = shardRangeObject.get("start").getAsInt();
+            int shardRangeEnd = shardRangeObject.get("end").getAsInt();
+            ShardRange shardRange = new ShardRange();
+            shardRange.setStart(shardRangeStart);
+            shardRange.setEnd(shardRangeEnd);
+
+            EppoValue typedValue = eppoValueAdapter.deserialize(variationObject.get("typedValue"), type, context);
+
+            Variation variation = new Variation();
+            variation.setShardRange(shardRange);
+            variation.setTypedValue(typedValue);
+            variations.add(variation);
+        }
+
+        return variations;
     }
 }

--- a/eppo/src/main/java/cloud/eppo/android/dto/deserializers/RandomizationConfigResponseDeserializer.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/deserializers/RandomizationConfigResponseDeserializer.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import cloud.eppo.android.EppoClient;
 import cloud.eppo.android.dto.Allocation;
 import cloud.eppo.android.dto.EppoValue;
 import cloud.eppo.android.dto.FlagConfig;
@@ -34,7 +33,7 @@ import cloud.eppo.android.dto.Variation;
  *  JSON-deserialization-related classes and annotations.
  */
 public class RandomizationConfigResponseDeserializer implements JsonDeserializer<RandomizationConfigResponse> {
-    private static final String TAG = logTag(EppoClient.class);
+    private static final String TAG = logTag(RandomizationConfigResponseDeserializer.class);
 
     private final EppoValueAdapter eppoValueAdapter = new EppoValueAdapter();
 

--- a/eppo/src/main/java/cloud/eppo/android/dto/deserializers/RandomizationConfigResponseDeserializer.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/deserializers/RandomizationConfigResponseDeserializer.java
@@ -27,7 +27,6 @@ import cloud.eppo.android.dto.ShardRange;
 import cloud.eppo.android.dto.TargetingCondition;
 import cloud.eppo.android.dto.TargetingRule;
 import cloud.eppo.android.dto.Variation;
-import cloud.eppo.android.dto.adapters.EppoValueAdapter;
 
 /**
  *  Hand-rolled deserializer so that we don't rely on annotations and method names, which can be
@@ -61,7 +60,7 @@ public class RandomizationConfigResponseDeserializer implements JsonDeserializer
         for (Map.Entry<String, JsonElement> flagEntry : flagsObject.entrySet()) {
             String flagKey = flagEntry.getKey();
             FlagConfig flagConfig = deserializeFlag(flagEntry.getValue(), type, context);
-            flags.put(flagKey, flagConfig);
+            flags.put(flagKey, flagConfig); // Note this is adding to the map already plugged into configResponse
         }
 
         return configResponse;

--- a/eppo/src/main/java/cloud/eppo/android/dto/deserializers/RandomizationConfigResponseDeserializer.java
+++ b/eppo/src/main/java/cloud/eppo/android/dto/deserializers/RandomizationConfigResponseDeserializer.java
@@ -1,0 +1,176 @@
+package cloud.eppo.android.dto.deserializers;
+
+import static cloud.eppo.android.util.Utils.logTag;
+
+import android.util.Log;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import cloud.eppo.android.EppoClient;
+import cloud.eppo.android.dto.Allocation;
+import cloud.eppo.android.dto.EppoValue;
+import cloud.eppo.android.dto.FlagConfig;
+import cloud.eppo.android.dto.OperatorType;
+import cloud.eppo.android.dto.RandomizationConfigResponse;
+import cloud.eppo.android.dto.ShardRange;
+import cloud.eppo.android.dto.TargetingCondition;
+import cloud.eppo.android.dto.TargetingRule;
+import cloud.eppo.android.dto.Variation;
+import cloud.eppo.android.dto.adapters.EppoValueAdapter;
+
+/**
+ *  Hand-rolled deserializer so that we don't rely on annotations and method names, which can be
+ *  unreliable when ProGuard minification is in-use and not configured to protect JSON-related
+ *  classes.
+ */
+public class RandomizationConfigResponseDeserializer implements JsonDeserializer<RandomizationConfigResponse> {
+    private static final String TAG = logTag(EppoClient.class);
+
+    private final EppoValueAdapter eppoValueAdapter = new EppoValueAdapter();
+
+    @Override
+    public RandomizationConfigResponse deserialize(JsonElement rootElement, Type type, JsonDeserializationContext context) throws JsonParseException {
+        ConcurrentHashMap<String, FlagConfig> flags = new ConcurrentHashMap<>();
+        RandomizationConfigResponse configResponse = new RandomizationConfigResponse();
+        configResponse.setFlags(flags);
+        if (rootElement == null || !rootElement.isJsonObject()) {
+            Log.w(TAG, "no top-level JSON object");
+            return configResponse;
+        }
+        JsonObject rootObject = rootElement.getAsJsonObject();
+        JsonElement flagsElement = rootObject.get("flags");
+        if (flagsElement == null) {
+            Log.w(TAG, "no root-level flags property");
+            return configResponse;
+        }
+        JsonObject flagsObject = flagsElement.getAsJsonObject();
+        for (Map.Entry<String, JsonElement> flagEntry : flagsObject.entrySet()) {
+            String flagKey = flagEntry.getKey();
+            JsonObject flagObject = flagEntry.getValue().getAsJsonObject();
+            int subjectShards = flagObject.get("subjectShards").getAsInt();
+            boolean enabled = flagObject.get("enabled").getAsBoolean();
+
+            Map<String, String> typedOverrides = new HashMap<>();
+            JsonElement typedOverridesElement = flagObject.get("typedOverrides");
+            if (typedOverridesElement != null) {
+                for (Map.Entry<String, JsonElement> typedOverridesEntry : typedOverridesElement.getAsJsonObject().entrySet()) {
+                    typedOverrides.put(typedOverridesEntry.getKey(), typedOverridesEntry.getValue().getAsString());
+
+                }
+            }
+
+            Map<String, Allocation> allocations = new HashMap<>();
+            JsonObject allocationsObject = flagObject.get("allocations").getAsJsonObject();
+            for (Map.Entry<String, JsonElement> allocationEntry : allocationsObject.entrySet()) {
+                String allocationKey = allocationEntry.getKey();
+                JsonObject allocationObject = allocationEntry.getValue().getAsJsonObject();
+                float percentExposure = allocationObject.get("percentExposure").getAsFloat();
+                JsonArray variationsArray = allocationObject.get("variations").getAsJsonArray();
+                List<Variation> variations = new ArrayList<>();
+                for (JsonElement variationElement : variationsArray) {
+                    JsonObject variationObject = variationElement.getAsJsonObject();
+
+                    JsonObject shardRangeObject = variationObject.get("shardRange").getAsJsonObject();
+                    int shardRangeStart = shardRangeObject.get("start").getAsInt();
+                    int shardRangeEnd = shardRangeObject.get("end").getAsInt();
+                    ShardRange shardRange = new ShardRange();
+                    shardRange.setStart(shardRangeStart);
+                    shardRange.setEnd(shardRangeEnd);
+
+                    EppoValue typedValue = eppoValueAdapter.deserialize(variationObject.get("typedValue"), type, context);
+
+                    Variation variation = new Variation();
+                    variation.setShardRange(shardRange);
+                    variation.setTypedValue(typedValue);
+                    variations.add(variation);
+                }
+
+                Allocation allocation = new Allocation();
+                allocation.setPercentExposure(percentExposure);
+                allocation.setVariations(variations);
+                allocations.put(allocationKey, allocation);
+            }
+
+            List<TargetingRule> targetingRules = new ArrayList<>();
+            for (JsonElement ruleElement : flagObject.getAsJsonArray("rules").getAsJsonArray()) {
+                JsonObject rulesObject = ruleElement.getAsJsonObject();
+                String allocationKey = rulesObject.get("allocationKey").getAsString();
+
+                List<TargetingCondition> conditions = new ArrayList<>();
+                for (JsonElement conditionElement : rulesObject.get("conditions").getAsJsonArray()) {
+                    JsonObject conditionObject = conditionElement.getAsJsonObject();
+                    String attribute = conditionObject.get("attribute").getAsString();
+                    OperatorType operator = OperatorType.fromString(conditionObject.get("operator").getAsString());
+                    EppoValue value = eppoValueAdapter.deserialize(conditionObject.get("value"), type, context);
+
+                    TargetingCondition condition = new TargetingCondition();
+                    condition.setAttribute(attribute);
+                    condition.setOperator(operator);
+                    condition.setValue(value);
+                    conditions.add(condition);
+                }
+
+                TargetingRule targetingRule = new TargetingRule();
+                targetingRule.setAllocationKey(allocationKey);
+                targetingRule.setConditions(conditions);
+                targetingRules.add(targetingRule);
+            }
+
+            FlagConfig flagConfig = new FlagConfig();
+            flagConfig.setEnabled(enabled);
+            flagConfig.setSubjectShards(subjectShards);
+            flagConfig.setTypedOverrides(typedOverrides);
+            flagConfig.setAllocations(allocations);
+            flagConfig.setRules(targetingRules);
+            flags.put(flagKey, flagConfig);
+        }
+
+        return configResponse;
+    }
+
+    private EppoValue deserializeToEppoValue(JsonElement element) {
+        EppoValue typedValue = EppoValue.valueOf(); // Default to null
+        if (element == null) {
+            return typedValue;
+        }
+
+        if (element.isJsonPrimitive()) {
+            JsonPrimitive primitive = element.getAsJsonPrimitive();
+            if (primitive.isBoolean()) {
+                typedValue = EppoValue.valueOf(primitive.getAsBoolean());
+            } else if (primitive.isNumber()) {
+                typedValue = EppoValue.valueOf(primitive.getAsDouble());
+            } else {
+                String stringPrimitive = primitive.getAsString();
+                if (stringPrimitive == "null") {
+                    // TODO: do we want to keep doing this?
+                } else {
+                    typedValue = EppoValue.valueOf();
+                }
+            }
+        } else if (element.isJsonArray()){
+            ArrayList<String> valueArray = new ArrayList<>();
+            for (JsonElement arrayElement : element.getAsJsonArray()) {
+                valueArray.add(arrayElement.getAsString());
+            }
+            typedValue = EppoValue.valueOf(valueArray);
+        } else if (element.isJsonObject()) {
+            typedValue = EppoValue.valueOf(element);
+        }
+
+        return typedValue;
+    }
+}

--- a/eppo/src/test/java/cloud/eppo/android/EppoValueDeserializerTest.java
+++ b/eppo/src/test/java/cloud/eppo/android/EppoValueDeserializerTest.java
@@ -13,7 +13,6 @@ import cloud.eppo.android.dto.adapters.EppoValueAdapter;
 
 public class EppoValueDeserializerTest {
     private EppoValueAdapter adapter = new EppoValueAdapter();
-    
 
     @Test
     public void testDeserializingDouble() throws Exception {

--- a/eppo/src/test/java/cloud/eppo/android/EppoValueDeserializerTest.java
+++ b/eppo/src/test/java/cloud/eppo/android/EppoValueDeserializerTest.java
@@ -9,7 +9,7 @@ import com.google.gson.JsonParser;
 import org.junit.Test;
 
 import cloud.eppo.android.dto.EppoValue;
-import cloud.eppo.android.dto.adapters.EppoValueAdapter;
+import cloud.eppo.android.dto.deserializers.EppoValueAdapter;
 
 public class EppoValueDeserializerTest {
     private EppoValueAdapter adapter = new EppoValueAdapter();

--- a/eppo/src/test/java/cloud/eppo/android/EppoValueDeserializerTest.java
+++ b/eppo/src/test/java/cloud/eppo/android/EppoValueDeserializerTest.java
@@ -1,7 +1,6 @@
 package cloud.eppo.android;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.gson.JsonElement;

--- a/eppo/src/test/java/cloud/eppo/android/RandomizationConfigResponseDeserializerTest.java
+++ b/eppo/src/test/java/cloud/eppo/android/RandomizationConfigResponseDeserializerTest.java
@@ -25,7 +25,7 @@ import cloud.eppo.android.dto.ShardRange;
 import cloud.eppo.android.dto.TargetingCondition;
 import cloud.eppo.android.dto.TargetingRule;
 import cloud.eppo.android.dto.Variation;
-import cloud.eppo.android.dto.adapters.EppoValueAdapter;
+import cloud.eppo.android.dto.deserializers.EppoValueAdapter;
 import cloud.eppo.android.dto.deserializers.RandomizationConfigResponseDeserializer;
 
 public class RandomizationConfigResponseDeserializerTest {

--- a/eppo/src/test/java/cloud/eppo/android/RandomizationConfigResponseDeserializerTest.java
+++ b/eppo/src/test/java/cloud/eppo/android/RandomizationConfigResponseDeserializerTest.java
@@ -1,0 +1,130 @@
+package cloud.eppo.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Map;
+import java.util.List;
+
+import cloud.eppo.android.dto.Allocation;
+import cloud.eppo.android.dto.EppoValue;
+import cloud.eppo.android.dto.FlagConfig;
+import cloud.eppo.android.dto.OperatorType;
+import cloud.eppo.android.dto.RandomizationConfigResponse;
+import cloud.eppo.android.dto.ShardRange;
+import cloud.eppo.android.dto.TargetingCondition;
+import cloud.eppo.android.dto.TargetingRule;
+import cloud.eppo.android.dto.Variation;
+import cloud.eppo.android.dto.adapters.EppoValueAdapter;
+import cloud.eppo.android.dto.deserializers.RandomizationConfigResponseDeserializer;
+
+public class RandomizationConfigResponseDeserializerTest {
+
+    private final Gson gson = new GsonBuilder()
+            .registerTypeAdapter(RandomizationConfigResponse.class, new RandomizationConfigResponseDeserializer())
+            .registerTypeAdapter(EppoValue.class, new EppoValueAdapter())
+            .serializeNulls()
+            .create();
+
+    @Test
+    public void testDeserialize() throws IOException {
+        File testRac = new File("src/androidTest/assets/rac-experiments-v3.json");
+        FileReader fileReader = new FileReader(testRac);
+        RandomizationConfigResponse configResponse = gson.fromJson(fileReader, RandomizationConfigResponse.class);
+
+        assertEquals(10, configResponse.getFlags().size());
+        assertTrue(configResponse.getFlags().containsKey("randomization_algo"));
+        assertTrue(configResponse.getFlags().containsKey("new_user_onboarding"));
+        assertTrue(configResponse.getFlags().containsKey("disabled_experiment_with_overrides"));
+        assertTrue(configResponse.getFlags().containsKey("targeting_rules_experiment"));
+        assertTrue(configResponse.getFlags().containsKey("experiment_with_numeric_variations"));
+        assertTrue(configResponse.getFlags().containsKey("experiment_with_json_variations"));
+        assertTrue(configResponse.getFlags().containsKey("test_bandit_1"));
+        assertTrue(configResponse.getFlags().containsKey("experiment_with_holdout"));
+        assertTrue(configResponse.getFlags().containsKey("rollout_with_holdout"));
+
+        FlagConfig flagConfig = configResponse.getFlags().get("disabled_experiment_with_overrides");
+        assertFalse(flagConfig.isEnabled());
+        assertEquals(10000, flagConfig.getSubjectShards());
+        Map<String, String> typedOverrides = flagConfig.getTypedOverrides();
+        assertEquals("treatment", typedOverrides.get("0bcbfc2660c78c549b0fbf870e3dc3ea"));
+        assertEquals("control", typedOverrides.get("50a681dcd4046400e5c675e85b69b4ac"));
+
+        List<TargetingRule> targetingRules = flagConfig.getRules();
+        assertEquals(1, targetingRules.size());
+        assertEquals("allocation-experiment-3", targetingRules.get(0).getAllocationKey());
+        assertTrue(targetingRules.get(0).getConditions().isEmpty());
+
+        Map<String, Allocation> allocations = flagConfig.getAllocations();
+        assertEquals(1, allocations.size());
+        Allocation allocation = allocations.get("allocation-experiment-3");
+        assertEquals(1.0, allocation.getPercentExposure(), 0.001);
+
+        List<Variation> variations = allocation.getVariations();
+        assertEquals(2, variations.size());
+
+        Variation controlVariation = variations.get(0);
+        assertEquals("control", controlVariation.getTypedValue().stringValue());
+        ShardRange controlShardRange = controlVariation.getShardRange();
+        assertEquals(0, controlShardRange.getStart());
+        assertEquals(5000, controlShardRange.getEnd());
+
+        Variation testVariation = variations.get(0);
+        assertEquals("treatment", testVariation.getTypedValue().stringValue());
+        ShardRange testShardRange = testVariation.getShardRange();
+        assertEquals(5000, testShardRange.getStart());
+        assertEquals(10000, testShardRange.getEnd());
+
+        // Need another flag to check targeting rules
+        flagConfig = configResponse.getFlags().get("targeting_rules_experiment");
+        assertTrue(flagConfig.isEnabled());
+        assertTrue(flagConfig.getTypedOverrides().isEmpty());
+        targetingRules = flagConfig.getRules();
+        assertEquals(3, targetingRules.size());
+
+        TargetingRule rule = targetingRules.get(0);
+        assertEquals("allocation-experiment-4", rule.getAllocationKey());
+        List<TargetingCondition> conditions = rule.getConditions();
+        assertEquals(2, conditions.size());
+        TargetingCondition condition = conditions.get(0);
+        assertEquals("device", condition.getAttribute());
+        assertEquals(OperatorType.OneOf,  condition.getOperator());
+        assertEquals("iOS", condition.getValue().arrayValue().get(0));
+        assertEquals("iOS", condition.getValue().arrayValue().get(1));
+
+        condition = conditions.get(1);
+        assertEquals("version", condition.getAttribute());
+        assertEquals(OperatorType.GreaterThan,  condition.getOperator());
+        assertEquals(1.0, condition.getValue().doubleValue(), 0.001);
+
+        rule = targetingRules.get(1);
+        assertEquals("allocation-experiment-4", rule.getAllocationKey());
+        conditions = rule.getConditions();
+        assertEquals(1, conditions.size());
+
+        condition = conditions.get(0);
+        assertEquals("country", condition.getAttribute());
+        assertEquals(OperatorType.NotOneOf,  condition.getOperator());
+        assertEquals("China", condition.getValue().stringValue());
+
+        rule = targetingRules.get(2);
+        assertEquals("allocation-experiment-4", rule.getAllocationKey());
+        conditions = rule.getConditions();
+        assertEquals(1, conditions.size());
+
+        condition = conditions.get(0);
+        assertEquals("email", condition.getAttribute());
+        assertEquals(OperatorType.Matches,  condition.getOperator());
+        assertEquals(".*geteppo.com", condition.getValue().stringValue());
+    }
+
+}

--- a/eppo/src/test/java/cloud/eppo/android/RandomizationConfigResponseDeserializerTest.java
+++ b/eppo/src/test/java/cloud/eppo/android/RandomizationConfigResponseDeserializerTest.java
@@ -2,6 +2,7 @@ package cloud.eppo.android;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.gson.Gson;
@@ -53,6 +54,7 @@ public class RandomizationConfigResponseDeserializerTest {
         assertTrue(configResponse.getFlags().containsKey("rollout_with_holdout"));
 
         FlagConfig flagConfig = configResponse.getFlags().get("disabled_experiment_with_overrides");
+        assertNotNull(flagConfig);
         assertFalse(flagConfig.isEnabled());
         assertEquals(10000, flagConfig.getSubjectShards());
         Map<String, String> typedOverrides = flagConfig.getTypedOverrides();
@@ -67,6 +69,7 @@ public class RandomizationConfigResponseDeserializerTest {
         Map<String, Allocation> allocations = flagConfig.getAllocations();
         assertEquals(1, allocations.size());
         Allocation allocation = allocations.get("allocation-experiment-3");
+        assertNotNull(allocation);
         assertEquals(1.0, allocation.getPercentExposure(), 0.001);
 
         List<Variation> variations = allocation.getVariations();
@@ -78,7 +81,7 @@ public class RandomizationConfigResponseDeserializerTest {
         assertEquals(0, controlShardRange.getStart());
         assertEquals(5000, controlShardRange.getEnd());
 
-        Variation testVariation = variations.get(0);
+        Variation testVariation = variations.get(1);
         assertEquals("treatment", testVariation.getTypedValue().stringValue());
         ShardRange testShardRange = testVariation.getShardRange();
         assertEquals(5000, testShardRange.getStart());
@@ -86,6 +89,7 @@ public class RandomizationConfigResponseDeserializerTest {
 
         // Need another flag to check targeting rules
         flagConfig = configResponse.getFlags().get("targeting_rules_experiment");
+        assertNotNull(flagConfig);
         assertTrue(flagConfig.isEnabled());
         assertTrue(flagConfig.getTypedOverrides().isEmpty());
         targetingRules = flagConfig.getRules();
@@ -95,11 +99,12 @@ public class RandomizationConfigResponseDeserializerTest {
         assertEquals("allocation-experiment-4", rule.getAllocationKey());
         List<TargetingCondition> conditions = rule.getConditions();
         assertEquals(2, conditions.size());
+
         TargetingCondition condition = conditions.get(0);
         assertEquals("device", condition.getAttribute());
         assertEquals(OperatorType.OneOf,  condition.getOperator());
         assertEquals("iOS", condition.getValue().arrayValue().get(0));
-        assertEquals("iOS", condition.getValue().arrayValue().get(1));
+        assertEquals("Android", condition.getValue().arrayValue().get(1));
 
         condition = conditions.get(1);
         assertEquals("version", condition.getAttribute());
@@ -114,7 +119,8 @@ public class RandomizationConfigResponseDeserializerTest {
         condition = conditions.get(0);
         assertEquals("country", condition.getAttribute());
         assertEquals(OperatorType.NotOneOf,  condition.getOperator());
-        assertEquals("China", condition.getValue().stringValue());
+        assertEquals(1, condition.getValue().arrayValue().size());
+        assertEquals("China", condition.getValue().arrayValue().get(0));
 
         rule = targetingRules.get(2);
         assertEquals("allocation-experiment-4", rule.getAllocationKey());

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -18,8 +18,9 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.debug
         }
     }
     compileOptions {

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -2,6 +2,12 @@ plugins {
     id 'com.android.application'
 }
 
+def localProperties = new Properties()
+def localPropertiesFile = rootProject.file('local.properties')
+if (localPropertiesFile.exists()) {
+    localProperties.load(new FileInputStream(localPropertiesFile))
+}
+
 android {
     compileSdk 33
 
@@ -14,6 +20,8 @@ android {
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+
+        buildConfigField "String", "API_KEY", "\"" + (localProperties['cloud.eppo.apiKey'] ?: "need to set cloud.eppo.apiKey in local.properties") + "\""
     }
 
     buildTypes {

--- a/example/src/main/java/cloud/eppo/androidexample/EppoApplication.java
+++ b/example/src/main/java/cloud/eppo/androidexample/EppoApplication.java
@@ -8,7 +8,7 @@ import cloud.eppo.android.InitializationCallback;
 
 public class EppoApplication extends Application {
     private static final String TAG = EppoApplication.class.getSimpleName();
-    private static final String API_KEY = "REPLACE WITH YOUR API KEY";
+    private static final String API_KEY = "DAXlGwLoDFYSskIUEDbyESt9lh8_1wG2uDMo9jvJo4I";
 
     @Override
     public void onCreate() {

--- a/example/src/main/java/cloud/eppo/androidexample/EppoApplication.java
+++ b/example/src/main/java/cloud/eppo/androidexample/EppoApplication.java
@@ -5,10 +5,11 @@ import android.util.Log;
 
 import cloud.eppo.android.EppoClient;
 import cloud.eppo.android.InitializationCallback;
+import com.geteppo.androidexample.BuildConfig;
 
 public class EppoApplication extends Application {
     private static final String TAG = EppoApplication.class.getSimpleName();
-    private static final String API_KEY = "DAXlGwLoDFYSskIUEDbyESt9lh8_1wG2uDMo9jvJo4I";
+    private static final String API_KEY = BuildConfig.API_KEY; // Set in root-level local.properties
 
     @Override
     public void onCreate() {


### PR DESCRIPTION
_Eppo Internal:_ 🎟️ **Ticket:** [FF-1892 - Android SDK Handle loading flags when using ProGuard minification](https://linear.app/eppo/issue/FF-1892/android-sdk-handle-loading-flags-when-using-proguard-minification)

Our existing JSON deserialization leveraged `gson`'s automatic mapping of JSON fields to Java Object properties based on their names. However, this would fail when those property names changed due to minification, such as by ProGuard. 

To get around this without the need to modify `proguard-rules.pro` (which could be at best burdonsome and at worst fragile), we explicitly define a deserializer and use that to parse the configuration response.

This was tested by building the example application with minification enabled. Before the changes, it didn't get assignments, but now it does! 🎉 

![image](https://github.com/Eppo-exp/android-sdk/assets/417605/96d5111a-e139-4701-8d8f-f6eb02ad93ae)