### PR TITLE
Handle if null initialization callback

### DIFF
--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "cloud.eppo"
-version = "1.0.6"
+version = "1.0.7"
 
 android {
     compileSdk 33

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -167,6 +167,7 @@ public class EppoClientTest {
                 })
                 .buildAndInit();
 
+        // Wait for initialization to succeed or fail, up to 10 seconds, before continuing
         try {
             if (!lock.await(10000, TimeUnit.MILLISECONDS)) {
                 throw new InterruptedException("Request for RAC did not complete within timeout");

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationRequestor.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationRequestor.java
@@ -29,7 +29,9 @@ public class ConfigurationRequestor {
             @Override
             public void onCacheLoadSuccess() {
                 cachedUsed.set(true);
-                callback.onCompleted();
+                if (callback != null) {
+                    callback.onCompleted();
+                }
             }
 
             @Override


### PR DESCRIPTION
There is one spot--where we successfully load the configuration from the file cache--where we don't check if the initialization callback is defined before attempting to call it. This adds in that check.