### PR TITLE
Better cache initialization

### DIFF
--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "cloud.eppo"
-version = "1.0.8"
+version = "1.0.9"
 
 android {
     compileSdk 33

--- a/eppo/src/main/java/cloud/eppo/android/ConfigCacheFile.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigCacheFile.java
@@ -10,13 +10,15 @@ import java.io.FileWriter;
 import java.io.IOException;
 
 public class ConfigCacheFile {
-    static final String CACHE_FILE_NAME = "eppo-sdk-config-v2.json";
-    private final File filesDir;
     private final File cacheFile;
 
-    public ConfigCacheFile(Application application) {
-        filesDir = application.getFilesDir();
-        cacheFile = new File(filesDir, CACHE_FILE_NAME);
+    public ConfigCacheFile(Application application, String keySuffix) {
+        File filesDir = application.getFilesDir();
+        cacheFile = new File(filesDir, cacheFileName(keySuffix));
+    }
+
+    public static String cacheFileName(String keySuffix) {
+        return "eppo-sdk-config-v3-" + keySuffix + ".json";
     }
 
     public boolean exists() {

--- a/eppo/src/main/java/cloud/eppo/android/ConfigCacheFile.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigCacheFile.java
@@ -12,13 +12,13 @@ import java.io.IOException;
 public class ConfigCacheFile {
     private final File cacheFile;
 
-    public ConfigCacheFile(Application application, String keySuffix) {
+    public ConfigCacheFile(Application application, String fileNameSuffix) {
         File filesDir = application.getFilesDir();
-        cacheFile = new File(filesDir, cacheFileName(keySuffix));
+        cacheFile = new File(filesDir, cacheFileName(fileNameSuffix));
     }
 
-    public static String cacheFileName(String keySuffix) {
-        return "eppo-sdk-config-v3-" + keySuffix + ".json";
+    public static String cacheFileName(String suffix) {
+        return "eppo-sdk-config-v3-" + suffix + ".json";
     }
 
     public boolean exists() {

--- a/eppo/src/main/java/cloud/eppo/android/ConfigCacheFile.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigCacheFile.java
@@ -2,12 +2,12 @@ package cloud.eppo.android;
 
 import android.app.Application;
 
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
 
 public class ConfigCacheFile {
     static final String CACHE_FILE_NAME = "eppo-sdk-config-v2.json";
@@ -29,13 +29,31 @@ public class ConfigCacheFile {
         }
     }
 
-    public OutputStreamWriter getOutputWriter() throws IOException {
-        FileOutputStream fos = new FileOutputStream(cacheFile);
-        return new OutputStreamWriter(fos);
+    /**
+     * Useful for passing in as a writer for gson serialization
+     */
+    public BufferedWriter getWriter() throws IOException {
+        return new BufferedWriter(new FileWriter(cacheFile));
     }
 
-    public InputStreamReader getInputReader() throws IOException {
-        FileInputStream fis = new FileInputStream(cacheFile);
-        return new InputStreamReader(fis);
+    /**
+     * Useful for passing in as a reader for gson deserialization
+     */
+    public BufferedReader getReader() throws IOException {
+        return new BufferedReader(new FileReader(cacheFile));
+    }
+
+    /**
+     * Useful for mocking caches in automated tests
+     */
+    public void setContents(String contents) {
+        delete();
+        try {
+            BufferedWriter writer = getWriter();
+            writer.write(contents);
+            writer.close();
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
     }
 }

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationRequestor.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationRequestor.java
@@ -45,6 +45,7 @@ public class ConfigurationRequestor {
             public void onSuccess(Reader response) {
                 try {
                     configurationStore.setFlags(response);
+                    Log.d(TAG, "Configuration fetch successful");
                 } catch (JsonSyntaxException | JsonIOException e) {
                     Log.e(TAG, "Error loading configuration response", e);
                     if (callback != null && !cachedUsed.get()) {
@@ -60,7 +61,7 @@ public class ConfigurationRequestor {
 
             @Override
             public void onFailure(String errorMessage) {
-                Log.e(TAG, errorMessage);
+                Log.e(TAG, "Error fetching configuration: " + errorMessage);
                 if (callback != null && !cachedUsed.get()) {
                     callback.onError(errorMessage);
                 }

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationRequestor.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationRequestor.java
@@ -44,7 +44,7 @@ public class ConfigurationRequestor {
             @Override
             public void onSuccess(Reader response) {
                 try {
-                    configurationStore.setFlags(response);
+                    configurationStore.setFlagsFromResponse(response);
                     Log.d(TAG, "Configuration fetch successful");
                 } catch (JsonSyntaxException | JsonIOException e) {
                     Log.e(TAG, "Error loading configuration response", e);

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
@@ -41,9 +41,9 @@ public class ConfigurationStore {
 
     private ConcurrentHashMap<String, FlagConfig> flags;
 
-    public ConfigurationStore(Application application) {
-        cacheFile = new ConfigCacheFile(application);
-        this.sharedPrefs = Utils.getSharedPrefs(application);
+    public ConfigurationStore(Application application, String keySuffix) {
+        cacheFile = new ConfigCacheFile(application, keySuffix);
+        this.sharedPrefs = Utils.getSharedPrefs(application, keySuffix);
     }
 
     public void loadFromCache(CacheLoadCallback callback) {

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
@@ -35,8 +35,8 @@ public class ConfigurationStore {
 
     private ConcurrentHashMap<String, FlagConfig> flags;
 
-    public ConfigurationStore(Application application, String keySuffix) {
-        cacheFile = new ConfigCacheFile(application, keySuffix);
+    public ConfigurationStore(Application application, String cacheFileNameSuffix) {
+        cacheFile = new ConfigCacheFile(application, cacheFileNameSuffix);
     }
 
     public void loadFromCache(CacheLoadCallback callback) {

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
@@ -13,7 +13,6 @@ import com.google.gson.JsonSyntaxException;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
-import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.HashSet;
 import java.util.Set;
@@ -86,6 +85,7 @@ public class ConfigurationStore {
             flags = new ConcurrentHashMap<>();
         } else {
             flags = config.getFlags();
+            Log.d(TAG, "Loaded" + flags.size() + "flags");
         }
 
         // update any existing flags already in shared prefs
@@ -138,6 +138,7 @@ public class ConfigurationStore {
     }
 
     private FlagConfig getFlagFromSharedPrefs(String hashedFlagKey) {
+        Log.d(TAG, "Attempting to load flag from shared preferences");
         try {
             return gson.fromJson(sharedPrefs.getString(hashedFlagKey, null), FlagConfig.class);
         } catch (Exception e) {
@@ -149,6 +150,7 @@ public class ConfigurationStore {
     public FlagConfig getFlag(String flagKey) {
         String hashedFlagKey = Utils.getMD5Hex(flagKey);
         if (flags == null) {
+            Log.d(TAG, "Flags not loaded yet");
             FlagConfig flagFromSharedPrefs = getFlagFromSharedPrefs(hashedFlagKey);
             if (flagFromSharedPrefs != null) {
                 return flagFromSharedPrefs;

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
@@ -11,8 +11,9 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.util.HashSet;
 import java.util.Set;
@@ -56,13 +57,16 @@ public class ConfigurationStore {
             Log.d(TAG, "Loading from cache");
             try {
                 synchronized (cacheFile) {
-                    InputStreamReader reader = cacheFile.getInputReader();
+                    BufferedReader reader = cacheFile.getReader();
                     RandomizationConfigResponse configResponse = gson.fromJson(reader, RandomizationConfigResponse.class);
                     reader.close();
                     if (configResponse == null || configResponse.getFlags() == null) {
                         throw new JsonSyntaxException("Configuration file missing flags");
                     }
                     flags = configResponse.getFlags();
+                    if (flags.isEmpty()) {
+                        throw new IllegalStateException("Cached configuration file has empty flags");
+                    }
                     updateConfigsInSharedPrefs();
                 }
                 Log.d(TAG, "Cache loaded successfully");
@@ -123,7 +127,7 @@ public class ConfigurationStore {
         AsyncTask.execute(() -> {
             try {
                 synchronized (cacheFile) {
-                    OutputStreamWriter writer = cacheFile.getOutputWriter();
+                    BufferedWriter writer = cacheFile.getWriter();
                     gson.toJson(config, writer);
                     writer.close();
                 }

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -1,6 +1,7 @@
 package cloud.eppo.android;
 
 import static cloud.eppo.android.util.Utils.logTag;
+import static cloud.eppo.android.util.Utils.safeCacheKey;
 import static cloud.eppo.android.util.Utils.validateNotEmptyOrNull;
 
 import android.app.ActivityManager;
@@ -10,7 +11,6 @@ import android.util.Log;
 
 import com.google.gson.JsonElement;
 
-import java.util.Date;
 import java.util.List;
 
 import cloud.eppo.android.dto.Allocation;
@@ -42,7 +42,8 @@ public class EppoClient {
     private EppoClient(Application application, String apiKey, String host, AssignmentLogger assignmentLogger,
             boolean isGracefulMode) {
         EppoHttpClient httpClient = httpClientOverride == null ? new EppoHttpClient(host, apiKey) : httpClientOverride;
-        ConfigurationStore configStore = new ConfigurationStore(application);
+        String cacheKeySuffix = safeCacheKey(apiKey); // Cache at a per-API key level (useful for development)
+        ConfigurationStore configStore = new ConfigurationStore(application, cacheKeySuffix);
         requestor = new ConfigurationRequestor(configStore, httpClient);
         this.isGracefulMode = isGracefulMode;
         this.assignmentLogger = assignmentLogger;

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -42,8 +42,8 @@ public class EppoClient {
     private EppoClient(Application application, String apiKey, String host, AssignmentLogger assignmentLogger,
             boolean isGracefulMode) {
         EppoHttpClient httpClient = httpClientOverride == null ? new EppoHttpClient(host, apiKey) : httpClientOverride;
-        String cacheKeySuffix = safeCacheKey(apiKey); // Cache at a per-API key level (useful for development)
-        ConfigurationStore configStore = new ConfigurationStore(application, cacheKeySuffix);
+        String cacheFileNameSuffix = safeCacheKey(apiKey); // Cache at a per-API key level (useful for development)
+        ConfigurationStore configStore = new ConfigurationStore(application, cacheFileNameSuffix);
         requestor = new ConfigurationRequestor(configStore, httpClient);
         this.isGracefulMode = isGracefulMode;
         this.assignmentLogger = assignmentLogger;

--- a/eppo/src/main/java/cloud/eppo/android/logging/Assignment.java
+++ b/eppo/src/main/java/cloud/eppo/android/logging/Assignment.java
@@ -46,6 +46,14 @@ public class Assignment {
         return experiment;
     }
 
+    public String getFeatureFlag() {
+        return featureFlag;
+    }
+
+    public String getAllocation() {
+        return allocation;
+    }
+
     public String getVariation() {
         return variation;
     }

--- a/eppo/src/main/java/cloud/eppo/android/util/Utils.java
+++ b/eppo/src/main/java/cloud/eppo/android/util/Utils.java
@@ -54,8 +54,14 @@ public class Utils {
         return dateFormat.format(date);
     }
 
-    public static SharedPreferences getSharedPrefs(Context context) {
-        return context.getSharedPreferences("eppo", Context.MODE_PRIVATE);
+    public static String safeCacheKey(String key) {
+        // Take the first eight characters to avoid the key being sensitive information
+        // Remove non-alphanumeric characters so it plays nice with filesystem
+        return key.substring(0,8).replaceAll("\\W", "");
+    }
+
+    public static SharedPreferences getSharedPrefs(Context context, String keySuffix) {
+        return context.getSharedPreferences("eppo-"+keySuffix, Context.MODE_PRIVATE);
     }
 
     public static String generateExperimentKey(String featureFlagKey, String allocationKey) {


### PR DESCRIPTION
_Eppo Internal:_
🎟️ **Ticket:** [FF-2092 - Cache should not succeed unless loaded flags & SDK key specific](https://linear.app/eppo/issue/FF-2092/cache-should-not-succeed-unless-loaded-flags-and-sdk-key-specific)
🗨️ **Slack Convo:** ["...There should be no race between SDK initialization and assignment..."](https://eppo-group.slack.com/archives/C0641KPCHP1/p1715789340639449?thread_ts=1714458577.930229&cid=C0641KPCHP1)

## Description
A user noticed an apparent race condition between initialization and assignment.
What is happening is that the client _thinks_ it successfully populated from a cached configuration, but that configuration is empty. It fires off the completion callback before fetching an updated configuration. Then `getAssignment()` is called with the empty configuration before the correct one is fetched.

One way this could happen is if an empty configuration is fetched and cached for one environment, and then the API key is changed to hit a different environment that has flags.

## Fix
To fix this, we require at least one flag to be present to consider loading from cache "successful".

Also, we make caching per-API key so that when switching between environments caches for the other environments are not used.

## Additional Step: Removing use of Shared Preferences (for now)
The Android SDK uses two layers of caching: the filesystem and Shared Preferences. The former is done asynchronously, so the latter was used as a backstop for a very fast assignment request right after initialization. This is a valid but unusual use case, so we've opted to remove the use of Shared Preferences for now, and we can fold it in later if needed.