### PR TITLE
Handle configuration fetching vs. cache race condition

### DIFF
--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "cloud.eppo"
-version = "1.0.9"
+version = "1.0.10"
 
 android {
     compileSdk 33

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -158,7 +158,7 @@ public class EppoClientTest {
         // Wait for initialization to succeed or fail, up to 10 seconds, before continuing
         try {
             if (!lock.await(10000, TimeUnit.MILLISECONDS)) {
-                throw new InterruptedException("Request for RAC did not complete within timeout");
+                throw new InterruptedException("Client initialization not complete within timeout");
             }
             Log.d(TAG, "Test client initialized");
         } catch (InterruptedException e) {
@@ -375,6 +375,7 @@ public class EppoClientTest {
         }).when(mockHttpClient).get(anyString(), any(RequestCallback.class));
 
         setHttpClientOverrideField(mockHttpClient);
+        initClient(TEST_HOST, true, true, false, DUMMY_API_KEY);
 
         String result = EppoClient.getInstance().getStringAssignment("dummy subject", "dummy flag");
         assertNull(result);
@@ -467,7 +468,7 @@ public class EppoClientTest {
           protected RandomizationConfigResponse readCacheFile() {
               Log.d(TAG, "Simulating slow cache read start");
               try {
-                  Thread.sleep(1000);
+                  Thread.sleep(2000);
               } catch (InterruptedException ex) {
                   throw new RuntimeException(ex);
               }
@@ -484,7 +485,7 @@ public class EppoClientTest {
 
         // Give time for async slow cache read to finish
         try {
-            Thread.sleep(1200);
+            Thread.sleep(2500);
         } catch (InterruptedException ex) {
             throw new RuntimeException(ex);
         }

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -48,6 +48,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import cloud.eppo.android.dto.EppoValue;
+import cloud.eppo.android.dto.FlagConfig;
 import cloud.eppo.android.dto.RandomizationConfigResponse;
 import cloud.eppo.android.dto.SubjectAttributes;
 import cloud.eppo.android.dto.deserializers.EppoValueAdapter;
@@ -473,14 +474,16 @@ public class EppoClientTest {
                   throw new RuntimeException(ex);
               }
               RandomizationConfigResponse response = new RandomizationConfigResponse();
-              response.setFlags(new ConcurrentHashMap<>());
+              ConcurrentHashMap<String, FlagConfig> mockFlags = new ConcurrentHashMap<>();
+              mockFlags.put("dummy", new FlagConfig()); // make the map non-empty
+              response.setFlags(mockFlags);
+
               Log.d(TAG, "Simulating slow cache read end");
               return response;
           }
         };
-        setConfigurationStoreOverrideField(slowStore);
 
-        // Init the client after locking the file so that fetch will finish first
+        setConfigurationStoreOverrideField(slowStore);
         initClient(TEST_HOST, true, false, false, DUMMY_API_KEY);
 
         // Give time for async slow cache read to finish

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationRequestor.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationRequestor.java
@@ -24,37 +24,41 @@ public class ConfigurationRequestor {
     }
 
     public void load(InitializationCallback callback) {
-        AtomicBoolean cachedUsed = new AtomicBoolean(false);
+        AtomicBoolean callbackCalled = new AtomicBoolean(false);
         configurationStore.loadFromCache(new CacheLoadCallback() {
             @Override
             public void onCacheLoadSuccess() {
-                cachedUsed.set(true);
-                if (callback != null) {
+                if (callback != null && callbackCalled.compareAndSet(false, true)) {
+                    Log.d(TAG, "Initialized from cache");
                     callback.onCompleted();
                 }
             }
 
             @Override
             public void onCacheLoadFail() {
-                cachedUsed.set(false);
+                // no-op; fall-back to Fetch
             }
         });
 
+        Log.d(TAG, "Fetching configuration");
         client.get("/api/randomized_assignment/v3/config", new RequestCallback() {
             @Override
             public void onSuccess(Reader response) {
                 try {
+                    Log.d(TAG, "Processing fetch response");
                     configurationStore.setFlagsFromResponse(response);
                     Log.d(TAG, "Configuration fetch successful");
                 } catch (JsonSyntaxException | JsonIOException e) {
                     Log.e(TAG, "Error loading configuration response", e);
-                    if (callback != null && !cachedUsed.get()) {
+                    if (callback != null && callbackCalled.compareAndSet(false, true)) {
+                        Log.d(TAG, "Initialization failure due to fetch response");
                         callback.onError("Unable to request configuration");
                     }
                     return;
                 }
 
-                if (callback != null && !cachedUsed.get()) {
+                if (callback != null && callbackCalled.compareAndSet(false, true)) {
+                    Log.d(TAG, "Initialized from fetch");
                     callback.onCompleted();
                 }
             }
@@ -62,7 +66,8 @@ public class ConfigurationRequestor {
             @Override
             public void onFailure(String errorMessage) {
                 Log.e(TAG, "Error fetching configuration: " + errorMessage);
-                if (callback != null && !cachedUsed.get()) {
+                if (callback != null && callbackCalled.compareAndSet(false, true)) {
+                    Log.d(TAG, "Initialization failure due to fetch error");
                     callback.onError(errorMessage);
                 }
             }

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
@@ -93,7 +93,7 @@ public class ConfigurationStore {
             flags = new ConcurrentHashMap<>();
         } else {
             flags = config.getFlags();
-            loadedFromFetchResponse.set(true); // Record flags set from a response so we don't later clobber them with a slow cache read
+            loadedFromFetchResponse.set(true); // Record that flags were set from a response so we don't later clobber them with a slow cache read
             Log.d(TAG, "Loaded " + flags.size() + " flags from configuration response");
         }
 

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
@@ -92,8 +92,8 @@ public class ConfigurationStore {
             Log.w(TAG, "Flags missing in configuration response");
             flags = new ConcurrentHashMap<>();
         } else {
-            flags = config.getFlags();
             loadedFromFetchResponse.set(true); // Record that flags were set from a response so we don't later clobber them with a slow cache read
+            flags = config.getFlags();
             Log.d(TAG, "Loaded " + flags.size() + " flags from configuration response");
         }
 

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -36,14 +36,16 @@ public class EppoClient {
     private boolean isGracefulMode;
     private static EppoClient instance;
 
-    // Useful for testing in situations where we want to mock the http client
+    // Useful for testing in situations where we want to mock the http client or configuration store
     private static EppoHttpClient httpClientOverride = null;
+    private static ConfigurationStore configurationStoreOverride = null;
+
 
     private EppoClient(Application application, String apiKey, String host, AssignmentLogger assignmentLogger,
             boolean isGracefulMode) {
         EppoHttpClient httpClient = httpClientOverride == null ? new EppoHttpClient(host, apiKey) : httpClientOverride;
         String cacheFileNameSuffix = safeCacheKey(apiKey); // Cache at a per-API key level (useful for development)
-        ConfigurationStore configStore = new ConfigurationStore(application, cacheFileNameSuffix);
+        ConfigurationStore configStore = configurationStoreOverride == null ? new ConfigurationStore(application, cacheFileNameSuffix) : configurationStoreOverride;
         requestor = new ConfigurationRequestor(configStore, httpClient);
         this.isGracefulMode = isGracefulMode;
         this.assignmentLogger = assignmentLogger;


### PR DESCRIPTION
_Eppo Internal:_
🎟️ **Ticket:** [FF-2111 - Android SDK should initialize with fetched data if it finishes before the cache load](https://linear.app/eppo/issue/FF-2111/android-sdk-should-initialize-with-fetched-data-if-it-finishes-before)
🗨️ **Slack Conversation:** ["...Race condition between cache access/http request?..."](https://eppo-group.slack.com/archives/C0641KPCHP1/p1715959937521589?thread_ts=1714458577.930229&cid=C0641KPCHP1)

While typically, one would expect file systems to be quicker than HTTP, this is not _guaranteed_. Especially if emulation is at play, the storage speed is slowed (encrypted, degraded), etc.

If the cache load finishes _after_ the configuration fetch, it is possible it may unintentionally overwrite that newly-obtained configuration with a cached, older version.

This PR tracks when flags are set via fetch so that they are not later overwritten by reading the cache. 

It also adds additional logging to help any future debugging.