### PR TITLE
External request - make 'EppoClient.refreshConfiguration' public

### DIFF
--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -78,7 +78,7 @@ public class EppoClient {
         return instance;
     }
 
-    private void refreshConfiguration(InitializationCallback callback) {
+    public void refreshConfiguration(InitializationCallback callback) {
         requestor.load(callback);
     }
 


### PR DESCRIPTION
Hi guys, an Android dev here. Recently we have started using your Android SDK in our app and noticed that there is no possibility to refresh the configuration after the app initialization, because the function 'refreshConfiguration' is private.
Sometimes we may need to refresh the configuration during the app's session. Could you make this method public so we would be able to refresh the configuration when needed? It is possible in iOS SDK, so I assume it could be possible in Android SDK as well?

Best,
Pawel