### PR TITLE
Pepare making 'EppoClient.refreshConfiguration' public for release

### DIFF
--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "cloud.eppo"
-version = "1.0.11"
+version = "1.0.12"
 
 android {
     compileSdk 33

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -78,6 +78,19 @@ public class EppoClient {
         return instance;
     }
 
+    /**
+     * Ability to ad-hoc kick off a configuration load.
+     * Will load from a filesystem cached file as well as fire off a HTTPS request for an updated
+     * configuration. If the cache load finishes first, those assignments will be used until the
+     * fetch completes.
+     *
+     * Deprecated, as we plan to make a more targeted and configurable way to do so in the future.
+     * @param callback methods to call when loading succeeds/fails. Note that the success callback
+     *                 will be called as soon as either a configuration is loaded from the cache or
+     *                 fetched--whichever finishes first. Error callback will called if both
+     *                 attempts fail.
+     */
+    @Deprecated
     public void refreshConfiguration(InitializationCallback callback) {
         requestor.load(callback);
     }


### PR DESCRIPTION
_Eppo Internal:_
🎟️ **Ticket:** [FF-2305](https://linear.app/eppo/issue/FF-2305/android-sdk-prep-and-release-booksy-change-to-make-loading-config)

To release external change request #52, which exposes `EppoClient`s `refreshConfiguration()` method, we want to bump the version and add a `@Deprecated` annotation.

The reason to flag it as `@Deprecated` out the gate is that this particular method--previously only used on initialization--also does some cache-loading stuff. Ideally, we'd pull out the HTTP stuff into a standalone public refresh method. That being said, this newly-exposed method will still accomplish a refresh. It will load whatever was previously fetched from the cache and update it when the fetch completes. However, it's a roundabout way that does more work than it has to, and we have plans to expand the API to have a true refresh request--hence the "deprecation".