### PR TITLE
Reuse test workflow for publishing

### DIFF
--- a/.github/workflows/publish-sdk.yaml
+++ b/.github/workflows/publish-sdk.yaml
@@ -7,9 +7,11 @@ env:
   ANDROID_API_LEVEL: 33
 
 jobs:
-  lint-test-sdk:
+  test:
+    uses: ./.github/workflows/test.yaml
+  publish:
+    needs: test
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
 
@@ -31,4 +33,4 @@ jobs:
           echo "MAVEN_PASSWORD=${MAVEN_PASSWORD}" >> ~/.gradle/gradle.properties
 
       - name: Publish
-        run: make publish-release
+        run: make check-maven-credentials-and-publish

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - '**/*'
+  workflow_call:
 
 jobs:
   test-android-sdk:


### PR DESCRIPTION
In #50 I changed the publish workflow to also test before publishing. This is a change we want. However, it fails because that workflow doesn't set up the emulated environment.

![image](https://github.com/Eppo-exp/android-sdk/assets/417605/abc0468e-2136-4fef-8b44-ef9210bc18db)

To fix this, I've changed things so that the publish workflow first calls the test workflow, leveraging GitHub's ability to [reuse workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows). I've made it so the publish job [depends on](https://docs.github.com/en/actions/using-jobs/using-jobs-in-a-workflow#defining-prerequisite-jobs) the test job succeeding.

