### PR TITLE
feat: Add `getJSONStringAssignment` API method

### DIFF
--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -187,6 +187,10 @@ public class EppoClientTest {
             .toString());
 
     assertEquals(
+        "{\"a\": 1, \"b\": false}",
+        spyClient.getJSONStringAssignment("subject1", "experiment1", "{\"a\": 1, \"b\": false}"));
+
+    assertEquals(
         new JSONObject("{}").toString(),
         spyClient
             .getJSONAssignment(

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -8,15 +8,7 @@ import static cloud.eppo.android.util.Utils.validateNotEmptyOrNull;
 import android.app.ActivityManager;
 import android.app.Application;
 import android.util.Log;
-
 import androidx.annotation.Nullable;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-
-import java.util.HashMap;
-import java.util.Map;
-
 import cloud.eppo.android.exceptions.MissingApiKeyException;
 import cloud.eppo.android.exceptions.MissingApplicationException;
 import cloud.eppo.android.exceptions.NotInitializedException;
@@ -26,6 +18,10 @@ import cloud.eppo.ufc.dto.EppoValue;
 import cloud.eppo.ufc.dto.FlagConfig;
 import cloud.eppo.ufc.dto.SubjectAttributes;
 import cloud.eppo.ufc.dto.VariationType;
+import java.util.HashMap;
+import java.util.Map;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 public class EppoClient {
   private static final String TAG = logTag(EppoClient.class);

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -8,7 +8,15 @@ import static cloud.eppo.android.util.Utils.validateNotEmptyOrNull;
 import android.app.ActivityManager;
 import android.app.Application;
 import android.util.Log;
+
 import androidx.annotation.Nullable;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.HashMap;
+import java.util.Map;
+
 import cloud.eppo.android.exceptions.MissingApiKeyException;
 import cloud.eppo.android.exceptions.MissingApplicationException;
 import cloud.eppo.android.exceptions.NotInitializedException;
@@ -18,10 +26,6 @@ import cloud.eppo.ufc.dto.EppoValue;
 import cloud.eppo.ufc.dto.FlagConfig;
 import cloud.eppo.ufc.dto.SubjectAttributes;
 import cloud.eppo.ufc.dto.VariationType;
-import java.util.HashMap;
-import java.util.Map;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 public class EppoClient {
   private static final String TAG = logTag(EppoClient.class);
@@ -352,6 +356,21 @@ public class EppoClient {
 
   public JSONObject getJSONAssignment(String flagKey, String subjectKey, JSONObject defaultValue) {
     return getJSONAssignment(flagKey, subjectKey, new SubjectAttributes(), defaultValue);
+  }
+
+  public String getJSONStringAssignment(String flagKey, String subjectKey, String defaultValue) {
+    try {
+      EppoValue value =
+          this.getTypedAssignment(
+              flagKey,
+              subjectKey,
+              new SubjectAttributes(),
+              EppoValue.valueOf(defaultValue),
+              VariationType.JSON);
+      return value.stringValue();
+    } catch (Exception e) {
+      return throwIfNotGraceful(e, defaultValue);
+    }
   }
 
   public JSONObject getJSONAssignment(

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -364,6 +364,16 @@ public class EppoClient {
     return getJSONAssignment(flagKey, subjectKey, new SubjectAttributes(), defaultValue);
   }
 
+  /**
+   * Returns the assignment for the provided feature flag key and subject key as a JSON String. If
+   * the flag is not found, does not match the requested type or is disabled, defaultValue is
+   * returned.
+   *
+   * @param flagKey the feature flag key
+   * @param subjectKey the subject key
+   * @param defaultValue the default value to return if the flag is not found
+   * @return the JSON string value of the assignment
+   */
   public JSONObject getJSONAssignment(
       String flagKey,
       String subjectKey,

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -8,15 +8,7 @@ import static cloud.eppo.android.util.Utils.validateNotEmptyOrNull;
 import android.app.ActivityManager;
 import android.app.Application;
 import android.util.Log;
-
 import androidx.annotation.Nullable;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-
-import java.util.HashMap;
-import java.util.Map;
-
 import cloud.eppo.android.exceptions.MissingApiKeyException;
 import cloud.eppo.android.exceptions.MissingApplicationException;
 import cloud.eppo.android.exceptions.NotInitializedException;
@@ -26,6 +18,10 @@ import cloud.eppo.ufc.dto.EppoValue;
 import cloud.eppo.ufc.dto.FlagConfig;
 import cloud.eppo.ufc.dto.SubjectAttributes;
 import cloud.eppo.ufc.dto.VariationType;
+import java.util.HashMap;
+import java.util.Map;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 public class EppoClient {
   private static final String TAG = logTag(EppoClient.class);
@@ -355,9 +351,10 @@ public class EppoClient {
   }
 
   /**
-   * Returns the assignment for the provided feature flag key and subject key as a {@link JSONObject}.
-   * If the flag is not found, does not match the requested type or is disabled, defaultValue is
-   * returned.
+   * Returns the assignment for the provided feature flag key and subject key as a {@link
+   * JSONObject}. If the flag is not found, does not match the requested type or is disabled,
+   * defaultValue is returned.
+   *
    * @param flagKey the feature flag key
    * @param subjectKey the subject key
    * @param defaultValue the default value to return if the flag is not found
@@ -388,9 +385,9 @@ public class EppoClient {
 
   /**
    * Returns the assignment for the provided feature flag key, subject key and subject attributes as
-   * a JSON string.
-   * If the flag is not found, does not match the requested type or is disabled, defaultValue is
-   * returned.
+   * a JSON string. If the flag is not found, does not match the requested type or is disabled,
+   * defaultValue is returned.
+   *
    * @param flagKey the feature flag key
    * @param subjectKey the subject key
    * @param defaultValue the default value to return if the flag is not found
@@ -413,9 +410,10 @@ public class EppoClient {
   }
 
   /**
-   * Returns the assignment for the provided feature flag key and subject key as a JSON String.
-   * If the flag is not found, does not match the requested type or is disabled, defaultValue is
+   * Returns the assignment for the provided feature flag key and subject key as a JSON String. If
+   * the flag is not found, does not match the requested type or is disabled, defaultValue is
    * returned.
+   *
    * @param flagKey the feature flag key
    * @param subjectKey the subject key
    * @param defaultValue the default value to return if the flag is not found

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -365,9 +365,9 @@ public class EppoClient {
   }
 
   /**
-   * Returns the assignment for the provided feature flag key and subject key as a JSON String. If
-   * the flag is not found, does not match the requested type or is disabled, defaultValue is
-   * returned.
+   * Returns the assignment for the provided feature flag key and subject key as a {@link
+   * JSONObject}. If the flag is not found, does not match the requested type or is disabled,
+   * defaultValue is returned.
    *
    * @param flagKey the feature flag key
    * @param subjectKey the subject key

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -8,7 +8,15 @@ import static cloud.eppo.android.util.Utils.validateNotEmptyOrNull;
 import android.app.ActivityManager;
 import android.app.Application;
 import android.util.Log;
+
 import androidx.annotation.Nullable;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.HashMap;
+import java.util.Map;
+
 import cloud.eppo.android.exceptions.MissingApiKeyException;
 import cloud.eppo.android.exceptions.MissingApplicationException;
 import cloud.eppo.android.exceptions.NotInitializedException;
@@ -18,10 +26,6 @@ import cloud.eppo.ufc.dto.EppoValue;
 import cloud.eppo.ufc.dto.FlagConfig;
 import cloud.eppo.ufc.dto.SubjectAttributes;
 import cloud.eppo.ufc.dto.VariationType;
-import java.util.HashMap;
-import java.util.Map;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 public class EppoClient {
   private static final String TAG = logTag(EppoClient.class);
@@ -350,6 +354,15 @@ public class EppoClient {
     }
   }
 
+  /**
+   * Returns the assignment for the provided feature flag key and subject key as a {@link JSONObject}.
+   * If the flag is not found, does not match the requested type or is disabled, defaultValue is
+   * returned.
+   * @param flagKey the feature flag key
+   * @param subjectKey the subject key
+   * @param defaultValue the default value to return if the flag is not found
+   * @return the JSON string value of the assignment
+   */
   public JSONObject getJSONAssignment(String flagKey, String subjectKey, JSONObject defaultValue) {
     return getJSONAssignment(flagKey, subjectKey, new SubjectAttributes(), defaultValue);
   }
@@ -373,6 +386,16 @@ public class EppoClient {
     }
   }
 
+  /**
+   * Returns the assignment for the provided feature flag key, subject key and subject attributes as
+   * a JSON string.
+   * If the flag is not found, does not match the requested type or is disabled, defaultValue is
+   * returned.
+   * @param flagKey the feature flag key
+   * @param subjectKey the subject key
+   * @param defaultValue the default value to return if the flag is not found
+   * @return the JSON string value of the assignment
+   */
   public String getJSONStringAssignment(
       String flagKey, String subjectKey, SubjectAttributes subjectAttributes, String defaultValue) {
     try {
@@ -380,7 +403,7 @@ public class EppoClient {
           this.getTypedAssignment(
               flagKey,
               subjectKey,
-              new SubjectAttributes(),
+              subjectAttributes,
               EppoValue.valueOf(defaultValue),
               VariationType.JSON);
       return value.stringValue();
@@ -389,6 +412,15 @@ public class EppoClient {
     }
   }
 
+  /**
+   * Returns the assignment for the provided feature flag key and subject key as a JSON String.
+   * If the flag is not found, does not match the requested type or is disabled, defaultValue is
+   * returned.
+   * @param flagKey the feature flag key
+   * @param subjectKey the subject key
+   * @param defaultValue the default value to return if the flag is not found
+   * @return the JSON string value of the assignment
+   */
   public String getJSONStringAssignment(String flagKey, String subjectKey, String defaultValue) {
     return this.getJSONStringAssignment(flagKey, subjectKey, new SubjectAttributes(), defaultValue);
   }

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -354,21 +354,6 @@ public class EppoClient {
     return getJSONAssignment(flagKey, subjectKey, new SubjectAttributes(), defaultValue);
   }
 
-  public String getJSONStringAssignment(String flagKey, String subjectKey, String defaultValue) {
-    try {
-      EppoValue value =
-          this.getTypedAssignment(
-              flagKey,
-              subjectKey,
-              new SubjectAttributes(),
-              EppoValue.valueOf(defaultValue),
-              VariationType.JSON);
-      return value.stringValue();
-    } catch (Exception e) {
-      return throwIfNotGraceful(e, defaultValue);
-    }
-  }
-
   public JSONObject getJSONAssignment(
       String flagKey,
       String subjectKey,
@@ -386,6 +371,26 @@ public class EppoClient {
     } catch (Exception e) {
       return throwIfNotGraceful(e, defaultValue);
     }
+  }
+
+  public String getJSONStringAssignment(
+      String flagKey, String subjectKey, SubjectAttributes subjectAttributes, String defaultValue) {
+    try {
+      EppoValue value =
+          this.getTypedAssignment(
+              flagKey,
+              subjectKey,
+              new SubjectAttributes(),
+              EppoValue.valueOf(defaultValue),
+              VariationType.JSON);
+      return value.stringValue();
+    } catch (Exception e) {
+      return throwIfNotGraceful(e, defaultValue);
+    }
+  }
+
+  public String getJSONStringAssignment(String flagKey, String subjectKey, String defaultValue) {
+    return this.getJSONStringAssignment(flagKey, subjectKey, new SubjectAttributes(), defaultValue);
   }
 
   @Nullable private JSONObject parseJsonString(String jsonString) {


### PR DESCRIPTION
# Description

This is the same as `getJSONAssignment` but returns a json `String` instead of a parsed `JSONObject`