### PR TITLE
fix: Publish build artifacts with release

### DIFF
--- a/.github/workflows/publish-sdk.yaml
+++ b/.github/workflows/publish-sdk.yaml
@@ -34,7 +34,7 @@ jobs:
           echo "GRADLE_USER_HOME=${HOME}/.gradle" >> $GITHUB_ENV
 
       - name: Publish Release artifact
-        run: ./gradlew publish -Prelease --no-daemon
+        run: ./gradlew eppo:assemble eppo:publish -Prelease --no-daemon
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -26,7 +26,7 @@ jobs:
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Publish Snapshot artifact
-        run: ./gradlew publish -Psnapshot --no-daemon
+        run: ./gradlew eppo:assemble eppo:publish -Psnapshot --no-daemon
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -49,6 +49,13 @@ android {
             excludes += "META-INF/**"
         }
     }
+
+    publishing {
+        singleVariant('release') {
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
 }
 
 ext {}
@@ -111,7 +118,7 @@ publishing {
             version = project.properties.get("version")
 
             afterEvaluate {
-                from components.findByName('release')
+                from components.release
             }
 
             pom {


### PR DESCRIPTION
## Description

This looks like a behavior change with Android Gradle plugin v8 as documented [here](https://stackoverflow.com/questions/71365373/software-components-will-not-be-created-automatically-for-maven-publishing-from/71366104#71366104)

This should fix the issue so that artifacts are properly uploaded with the release.

## Testing

Verified locally by creating a separate repository and importing the `3.2.0-SNAPSHOT` into it with this code