### PR TITLE
fix: Export `sdk-common-jvm` to consumers of `android-sdk`

### DIFF
--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -75,7 +75,7 @@ ext.versions = [
 
 
 dependencies {
-    implementation 'cloud.eppo:sdk-common-jvm:2.0.0-SNAPSHOT'
+    api 'cloud.eppo:sdk-common-jvm:2.0.0-SNAPSHOT'
     implementation "androidx.core:core:${versions.androidx_core}"
     implementation "com.squareup.okhttp3:okhttp:${versions.okhttp}"
     implementation "com.github.zafarkhaja:java-semver:${versions.semver}"

--- a/example/src/main/java/cloud/eppo/androidexample/SecondActivity.java
+++ b/example/src/main/java/cloud/eppo/androidexample/SecondActivity.java
@@ -15,6 +15,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import com.geteppo.androidexample.R;
 
 import cloud.eppo.android.EppoClient;
+import cloud.eppo.ufc.dto.SubjectAttributes;
 
 public class SecondActivity extends AppCompatActivity {
     private EditText experiment;
@@ -51,7 +52,8 @@ public class SecondActivity extends AppCompatActivity {
             return;
         }
 
-        String assignedVariation = EppoClient.getInstance().getStringAssignment(experimentKey, subjectId, "");
+        String assignedVariation = EppoClient.getInstance().getStringAssignment(
+            experimentKey, subjectId, new SubjectAttributes(), "");
         appendToAssignmentLogView("Assigned variation: " + assignedVariation);
     }
 


### PR DESCRIPTION
## Description

This fixes an issue where users of `android-sdk` couldn't reference classes from `sdk-common-jvm` like `SubjectAttributes` because they were not exposed.
More info on the differences: https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation