### PR TITLE
fix: Update README usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ feature flagging and experimentation for Eppo customers. An API key is required 
 dependencies {
   implementation 'cloud.eppo:android-sdk:3.2.0'
 }
+
+dependencyResolutionManagement {
+  repositories {
+    maven {
+      url "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+    }
+  }
+}
 ```
 Snapshots of the development version are available in [Sonatype's snapshots repository](https://s01.oss.sonatype.org/content/repositories/snapshots/).
 


### PR DESCRIPTION
This is a temporary fix while I get us out of the snapshot version of `sdk-common-jvm` - will have a PR for that as soon as I release v2 of that