### PR TITLE
bug: [add support for json array variation values] (FF-2900)

### DIFF
--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -20,6 +20,8 @@ import cloud.eppo.ufc.dto.SubjectAttributes;
 import cloud.eppo.ufc.dto.VariationType;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -433,9 +435,19 @@ public class EppoClient {
     return this.getJSONStringAssignment(flagKey, subjectKey, new SubjectAttributes(), defaultValue);
   }
 
-  @Nullable private JSONObject parseJsonString(String jsonString) {
+  @Nullable
+  private JSONObject parseJsonString(String jsonString) {
     try {
-      return new JSONObject(jsonString);
+      if (jsonString.trim().startsWith("{")) {
+        return new JSONObject(jsonString);
+      } else if (jsonString.trim().startsWith("[")) {
+        JSONArray jsonArray = new JSONArray(jsonString);
+        JSONObject wrapper = new JSONObject();
+        wrapper.put("array", jsonArray);
+        return wrapper;
+      } else {
+        return null;
+      }
     } catch (JSONException e) {
       return null;
     }

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -20,7 +20,6 @@ import cloud.eppo.ufc.dto.SubjectAttributes;
 import cloud.eppo.ufc.dto.VariationType;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -435,8 +434,7 @@ public class EppoClient {
     return this.getJSONStringAssignment(flagKey, subjectKey, new SubjectAttributes(), defaultValue);
   }
 
-  @Nullable
-  private JSONObject parseJsonString(String jsonString) {
+  @Nullable private JSONObject parseJsonString(String jsonString) {
     try {
       if (jsonString.trim().startsWith("{")) {
         return new JSONObject(jsonString);


### PR DESCRIPTION
## observation

android sdk fails to parse variation values that are top level arrays.

## changes

Attempts to detect whether the json string is an array or an object.

## testing

added this condition to our test files: https://github.com/Eppo-exp/sdk-test-data/pull/50

the integration test for the android repo picks it up and succeeds.