### PR TITLE
chore: upgrade from deprecated version of actions/upload-artifact

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -127,14 +127,14 @@ jobs:
 
       - name: Upload Emulator Logs
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: emulator logs
           path: app/emulator.log
 
       - name: Upload Test Report
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: report
           path: /Users/runner/work/android-sdk/android-sdk/eppo/build/reports/androidTests/connected/index.html


### PR DESCRIPTION
Tests are automatically failing from using a deprecated version of actions/upload-artifact.
[Deprecation Notice](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/)

failing tests
![Screenshot 2024-09-12 at 9 56 08 AM](https://github.com/user-attachments/assets/839bd6c5-9633-4676-9092-d21c48289929)

Now running & passing tests
![Screenshot 2024-09-12 at 10 02 26 AM](https://github.com/user-attachments/assets/f9b1102f-78f0-4353-bca8-a5aa6c644206)
