### PR TITLE
fix: Rename publish username/password

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -5,8 +5,8 @@ on:
     branches: [main]
 
 env:
-  ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
-  ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
+  ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
+  ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
   CI: true
 
 jobs:


### PR DESCRIPTION
This new plugin expects the username and password env vars to be `mavenCentralUsername` and `mavenCentralPassword` instead