### PR TITLE
fix: Bump minSdk version to 26

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -127,7 +127,6 @@ jobs:
           disable-animations: true
           script: |
             echo "Emulator started" 
-            adb logcat -c                                     # clear logs
             mkdir -p app/                                     # create directory
             touch app/emulator.log                            # create log file
             chmod 777 app/emulator.log                        # allow writing to log file

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        api-level: [24, 26, 31, 34]
+        api-level: [26, 31, 34]
       # Allow other tests to continue if one fails
       fail-fast: false
 

--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -57,29 +57,29 @@ ext.versions = [
     "junit": "4.13.2",
     "mockito": "3.+",
     "roboelectric": "4.12+",
-    "androidx_junit": "1.1.5",
-    "androidx_test_core": "1.5.0",
-    "androidx_runner": "1.5.2",
-    "androidx_core": "1.9.0",
+    "androidx_junit": "1.2.1",
+    "androidx_test_core": "1.6.1",
+    "androidx_runner": "1.6.2",
+    "androidx_core": "1.13.1",
     "gson": "2.9.1",
     "okhttp": "4.12.0",
-    "commonsio": "2.14.0",
+    "commonsio": "2.17.0",
     "semver": "0.10.2"
 ]
 
 dependencies {
-    api 'cloud.eppo:sdk-common-jvm:3.4.1-SNAPSHOT'
+    api 'cloud.eppo:sdk-common-jvm:3.4.1'
 
     implementation 'org.slf4j:slf4j-api:2.0.16'
     implementation 'uk.uuid.slf4j:slf4j-android:2.0.16-0'
 
     implementation "androidx.core:core:${versions.androidx_core}"
-    implementation 'commons-io:commons-io:2.17.0'
     implementation "com.squareup.okhttp3:okhttp:${versions.okhttp}"
     implementation "com.github.zafarkhaja:java-semver:${versions.semver}"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.18.0"
 
     testImplementation "junit:junit:${versions.junit}"
+    testImplementation "commons-io:commons-io:${versions.commonsio}"
     testImplementation "org.mockito:mockito-core:${versions.mockito}"
     testImplementation "org.robolectric:robolectric:${versions.roboelectric}"
     androidTestImplementation "org.mockito:mockito-android:${versions.mockito}"

--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -15,8 +15,8 @@ android {
 
     defaultConfig {
         namespace "cloud.eppo.android"
-        minSdk 24
-        targetSdk 33
+        minSdk 26
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -68,7 +68,7 @@ ext.versions = [
 ]
 
 dependencies {
-    api 'cloud.eppo:sdk-common-jvm:3.4.0'
+    api 'cloud.eppo:sdk-common-jvm:3.4.1-SNAPSHOT'
 
     implementation 'org.slf4j:slf4j-api:2.0.16'
     implementation 'uk.uuid.slf4j:slf4j-android:2.0.16-0'

--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -55,7 +55,7 @@ android {
 ext {}
 ext.versions = [
     "junit": "4.13.2",
-    "mockito": "3.+",
+    "mockito": "5.14.2",
     "roboelectric": "4.12+",
     "androidx_junit": "1.2.1",
     "androidx_test_core": "1.6.1",
@@ -80,7 +80,7 @@ dependencies {
 
     testImplementation "junit:junit:${versions.junit}"
     testImplementation "commons-io:commons-io:${versions.commonsio}"
-    testImplementation "org.mockito:mockito-core:${versions.mockito}"
+    testImplementation "org.mockito:mockito-android:${versions.mockito}"
     testImplementation "org.robolectric:robolectric:${versions.roboelectric}"
     androidTestImplementation "org.mockito:mockito-android:${versions.mockito}"
     androidTestImplementation "androidx.test.ext:junit:${versions.androidx_junit}"

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -1,5 +1,8 @@
 package cloud.eppo.android;
 
+import static cloud.eppo.android.ConfigCacheFile.cacheFileName;
+import static cloud.eppo.android.util.Utils.logTag;
+import static cloud.eppo.android.util.Utils.safeCacheKey;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -13,44 +16,11 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static cloud.eppo.android.ConfigCacheFile.cacheFileName;
-import static cloud.eppo.android.util.Utils.logTag;
-import static cloud.eppo.android.util.Utils.safeCacheKey;
 
 import android.content.res.AssetManager;
 import android.util.Log;
-
 import androidx.annotation.Nullable;
 import androidx.test.core.app.ApplicationProvider;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-
-import org.apache.commons.io.Charsets;
-import org.apache.commons.io.IOUtils;
-import org.json.JSONException;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.reflect.Field;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
 import cloud.eppo.BaseEppoClient;
 import cloud.eppo.EppoHttpClient;
 import cloud.eppo.android.helpers.AssignmentTestCase;
@@ -65,6 +35,31 @@ import cloud.eppo.logging.AssignmentLogger;
 import cloud.eppo.ufc.dto.FlagConfig;
 import cloud.eppo.ufc.dto.FlagConfigResponse;
 import cloud.eppo.ufc.dto.VariationType;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.commons.io.Charsets;
+import org.apache.commons.io.IOUtils;
+import org.json.JSONException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 public class EppoClientTest {
   private static final String TAG = logTag(EppoClient.class);
@@ -370,9 +365,7 @@ public class EppoClientTest {
     return testCase.getSubjects().size();
   }
 
-  /**
-   * Helper method for asserting a subject assignment with a useful failure message.
-   */
+  /** Helper method for asserting a subject assignment with a useful failure message. */
   private <T> void assertAssignment(
       String flagKey, SubjectAssignment expectedSubjectAssignment, T assignment) {
 
@@ -490,35 +483,35 @@ public class EppoClientTest {
     // Set the experiment_with_boolean_variations flag to always return true
     byte[] jsonBytes =
         ("{\n"
-            + "  \"createdAt\": \"2024-04-17T19:40:53.716Z\",\n"
-            + "  \"flags\": {\n"
-            + "    \"2c27190d8645fe3bc3c1d63b31f0e4ee\": {\n"
-            + "      \"key\": \"2c27190d8645fe3bc3c1d63b31f0e4ee\",\n"
-            + "      \"enabled\": true,\n"
-            + "      \"variationType\": \"NUMERIC\",\n"
-            + "      \"totalShards\": 10000,\n"
-            + "      \"variations\": {\n"
-            + "        \"cGk=\": {\n"
-            + "          \"key\": \"cGk=\",\n"
-            + "          \"value\": \"MS4yMzQ1\"\n"
-            + // Changed to be 1.2345 encoded
-            "        }\n"
-            + "      },\n"
-            + "      \"allocations\": [\n"
-            + "        {\n"
-            + "          \"key\": \"cm9sbG91dA==\",\n"
-            + "          \"doLog\": true,\n"
-            + "          \"splits\": [\n"
-            + "            {\n"
-            + "              \"variationKey\": \"cGk=\",\n"
-            + "              \"shards\": []\n"
-            + "            }\n"
-            + "          ]\n"
-            + "        }\n"
-            + "      ]\n"
-            + "    }\n"
-            + "  }\n"
-            + "}")
+                + "  \"createdAt\": \"2024-04-17T19:40:53.716Z\",\n"
+                + "  \"flags\": {\n"
+                + "    \"2c27190d8645fe3bc3c1d63b31f0e4ee\": {\n"
+                + "      \"key\": \"2c27190d8645fe3bc3c1d63b31f0e4ee\",\n"
+                + "      \"enabled\": true,\n"
+                + "      \"variationType\": \"NUMERIC\",\n"
+                + "      \"totalShards\": 10000,\n"
+                + "      \"variations\": {\n"
+                + "        \"cGk=\": {\n"
+                + "          \"key\": \"cGk=\",\n"
+                + "          \"value\": \"MS4yMzQ1\"\n"
+                + // Changed to be 1.2345 encoded
+                "        }\n"
+                + "      },\n"
+                + "      \"allocations\": [\n"
+                + "        {\n"
+                + "          \"key\": \"cm9sbG91dA==\",\n"
+                + "          \"doLog\": true,\n"
+                + "          \"splits\": [\n"
+                + "            {\n"
+                + "              \"variationKey\": \"cGk=\",\n"
+                + "              \"shards\": []\n"
+                + "            }\n"
+                + "          ]\n"
+                + "        }\n"
+                + "      ]\n"
+                + "    }\n"
+                + "  }\n"
+                + "}")
             .getBytes();
     cacheFile2
         .getOutputStream()
@@ -662,9 +655,7 @@ public class EppoClientTest {
     setBaseClientOverrideField("httpClientOverride", httpClient);
   }
 
-  /**
-   * Uses reflection to set a static override field used for tests (e.g., httpClientOverride)
-   */
+  /** Uses reflection to set a static override field used for tests (e.g., httpClientOverride) */
   @SuppressWarnings("SameParameterValue")
   public static <T> void setBaseClientOverrideField(String fieldName, T override) {
     try {

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
@@ -4,18 +4,15 @@ import static cloud.eppo.android.util.Utils.logTag;
 
 import android.app.Application;
 import android.util.Log;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
+import cloud.eppo.IConfigurationStore;
+import cloud.eppo.android.util.Utils;
+import cloud.eppo.api.Configuration;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.concurrent.CompletableFuture;
-
-import cloud.eppo.IConfigurationStore;
-import cloud.eppo.android.util.Utils;
-import cloud.eppo.api.Configuration;
 
 public class ConfigurationStore implements IConfigurationStore {
 

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
@@ -7,12 +7,12 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import cloud.eppo.IConfigurationStore;
+import cloud.eppo.android.util.Utils;
 import cloud.eppo.api.Configuration;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.concurrent.CompletableFuture;
-import org.apache.commons.io.IOUtils;
 
 public class ConfigurationStore implements IConfigurationStore {
 
@@ -54,7 +54,7 @@ public class ConfigurationStore implements IConfigurationStore {
     synchronized (cacheLock) {
       try (InputStream inputStream = cacheFile.getInputStream()) {
         Log.d(TAG, "Attempting to inflate config");
-        Configuration config = new Configuration.Builder(IOUtils.toByteArray(inputStream)).build();
+        Configuration config = new Configuration.Builder(Utils.toByteArray(inputStream)).build();
         Log.d(TAG, "Cache load complete");
         return config;
       } catch (IOException e) {

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
@@ -4,15 +4,18 @@ import static cloud.eppo.android.util.Utils.logTag;
 
 import android.app.Application;
 import android.util.Log;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import cloud.eppo.IConfigurationStore;
-import cloud.eppo.android.util.Utils;
-import cloud.eppo.api.Configuration;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.concurrent.CompletableFuture;
+
+import cloud.eppo.IConfigurationStore;
+import cloud.eppo.android.util.Utils;
+import cloud.eppo.api.Configuration;
 
 public class ConfigurationStore implements IConfigurationStore {
 

--- a/eppo/src/main/java/cloud/eppo/android/util/Utils.java
+++ b/eppo/src/main/java/cloud/eppo/android/util/Utils.java
@@ -1,12 +1,16 @@
 package cloud.eppo.android.util;
 
 import android.util.Base64;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 
-public class Utils {
+public final class Utils {
+  private static final int BUFFER_SIZE = 8192;
   private static final SimpleDateFormat isoUtcDateFormat = buildUtcIsoDateFormat();
 
   public static String base64Encode(String input) {
@@ -59,6 +63,16 @@ public class Utils {
     }
 
     return logTag;
+  }
+
+  public static byte[] toByteArray(InputStream input) throws IOException {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    byte[] buffer = new byte[BUFFER_SIZE];
+    int n;
+    while ((n = input.read(buffer)) != -1) {
+      output.write(buffer, 0, n);
+    }
+    return output.toByteArray();
   }
 
   private static SimpleDateFormat buildUtcIsoDateFormat() {

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -16,7 +16,7 @@ android {
     defaultConfig {
         applicationId "cloud.eppo.androidexample"
         namespace "com.geteppo.androidexample"
-        minSdk 24
+        minSdk 26
         targetSdk 34
         versionCode 2
         versionName "2.0"

--- a/example/src/main/java/cloud/eppo/androidexample/MainActivity.java
+++ b/example/src/main/java/cloud/eppo/androidexample/MainActivity.java
@@ -9,11 +9,14 @@ import android.os.Bundle;
 import android.text.TextUtils;
 import android.widget.Button;
 import android.widget.Toast;
+
 import androidx.appcompat.app.AppCompatActivity;
-import cloud.eppo.android.ConfigCacheFile;
-import cloud.eppo.android.EppoClient;
+
 import com.geteppo.androidexample.BuildConfig;
 import com.geteppo.androidexample.R;
+
+import cloud.eppo.android.ConfigCacheFile;
+import cloud.eppo.android.EppoClient;
 
 public class MainActivity extends AppCompatActivity {
   private static final String API_KEY = BuildConfig.API_KEY; // Set in root-level local.properties
@@ -23,7 +26,6 @@ public class MainActivity extends AppCompatActivity {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
     Button button = findViewById(R.id.button_start_assigner);
-
     Intent launchAssigner = new Intent(MainActivity.this, SecondActivity.class);
 
     button.setOnClickListener(view -> startActivity(launchAssigner));
@@ -31,7 +33,7 @@ public class MainActivity extends AppCompatActivity {
     Button offlineButton = findViewById(R.id.button_start_offline_assigner);
     offlineButton.setOnClickListener(
         view ->
-            startActivity(launchAssigner.putExtra(this.getPackageName() + ".offlineMode", true)));
+            startActivity(launchAssigner.putExtra(this.getPackageName() + ".offlineMode", false)));
 
     Button clearCacheButton = findViewById(R.id.button_clear_cache);
     clearCacheButton.setOnClickListener(view -> clearCacheFile());

--- a/example/src/main/java/cloud/eppo/androidexample/MainActivity.java
+++ b/example/src/main/java/cloud/eppo/androidexample/MainActivity.java
@@ -9,14 +9,11 @@ import android.os.Bundle;
 import android.text.TextUtils;
 import android.widget.Button;
 import android.widget.Toast;
-
 import androidx.appcompat.app.AppCompatActivity;
-
-import com.geteppo.androidexample.BuildConfig;
-import com.geteppo.androidexample.R;
-
 import cloud.eppo.android.ConfigCacheFile;
 import cloud.eppo.android.EppoClient;
+import com.geteppo.androidexample.BuildConfig;
+import com.geteppo.androidexample.R;
 
 public class MainActivity extends AppCompatActivity {
   private static final String API_KEY = BuildConfig.API_KEY; // Set in root-level local.properties

--- a/example/src/main/java/cloud/eppo/androidexample/SecondActivity.java
+++ b/example/src/main/java/cloud/eppo/androidexample/SecondActivity.java
@@ -10,14 +10,11 @@ import android.view.View;
 import android.widget.EditText;
 import android.widget.ScrollView;
 import android.widget.TextView;
-
 import androidx.appcompat.app.AppCompatActivity;
-
-import com.geteppo.androidexample.BuildConfig;
-import com.geteppo.androidexample.R;
-
 import cloud.eppo.android.EppoClient;
 import cloud.eppo.api.Attributes;
+import com.geteppo.androidexample.BuildConfig;
+import com.geteppo.androidexample.R;
 
 public class SecondActivity extends AppCompatActivity {
   private static final String TAG = SecondActivity.class.getSimpleName();

--- a/example/src/main/java/cloud/eppo/androidexample/SecondActivity.java
+++ b/example/src/main/java/cloud/eppo/androidexample/SecondActivity.java
@@ -10,11 +10,14 @@ import android.view.View;
 import android.widget.EditText;
 import android.widget.ScrollView;
 import android.widget.TextView;
+
 import androidx.appcompat.app.AppCompatActivity;
-import cloud.eppo.android.EppoClient;
-import cloud.eppo.api.Attributes;
+
 import com.geteppo.androidexample.BuildConfig;
 import com.geteppo.androidexample.R;
+
+import cloud.eppo.android.EppoClient;
+import cloud.eppo.api.Attributes;
 
 public class SecondActivity extends AppCompatActivity {
   private static final String TAG = SecondActivity.class.getSimpleName();
@@ -33,9 +36,8 @@ public class SecondActivity extends AppCompatActivity {
         extras != null && extras.getBoolean(this.getPackageName() + ".offlineMode", false);
 
     new EppoClient.Builder(API_KEY, getApplication())
-        .isGracefulMode(true)
+        .isGracefulMode(false)
         .offlineMode(offlineMode)
-        .forceReinitialize(true)
         .assignmentLogger(
             assignment -> {
               Log.d(

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -34,7 +34,7 @@
             android:layout_height="wrap_content"
 
 
-            android:backgroundTint="@color/material_dynamic_primary50"
+            android:backgroundTint="#000000"
             android:text="@string/clear_cache" />
 
     </LinearLayout>


### PR DESCRIPTION
[Jackson v2.13](https://github.com/FasterXML/jackson/wiki/Jackson-Releases) [dropped](https://github.com/FasterXML/jackson-module-kotlin/issues/716#issuecomment-1765071697) support for Android version below 26, so this was just instacrashing on Android 24 and 25 with:
```
 Process: cloud.eppo.androidexample, PID: 4545
    java.lang.NoClassDefFoundError: Failed resolution of: Ljava/lang/BootstrapMethodError;
        at com.fasterxml.jackson.databind.util.ExceptionUtil.isFatal(ExceptionUtil.java:51)
        at com.fasterxml.jackson.databind.util.ExceptionUtil.rethrowIfFatal(ExceptionUtil.java:31)
        at com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector.<clinit>(JacksonAnnotationIntrospector.java:70)
        at com.fasterxml.jackson.databind.ObjectMapper.<clinit>(ObjectMapper.java:402)
        at cloud.eppo.BaseEppoClient.<init>(BaseEppoClient.java:25)
        at cloud.eppo.android.EppoClient.<init>(EppoClient.java:42)
        at cloud.eppo.android.EppoClient.<init>(EppoClient.java:24)
        at cloud.eppo.android.EppoClient$Builder.buildAndInitAsync(EppoClient.java:210)
        at cloud.eppo.androidexample.SecondActivity.onCreate(SecondActivity.java:53)
        at android.app.Activity.performCreate(Activity.java:6662)
        at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1118)
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2599)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2707)
        at android.app.ActivityThread.-wrap12(ActivityThread.java)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1460)
        at android.os.Handler.dispatchMessage(Handler.java:102)
        at android.os.Looper.loop(Looper.java:154)
        at android.app.ActivityThread.main(ActivityThread.java:6077)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:866)
```

Plus, with minSdk 26 we can use `java.util.Base64`, which was added on https://github.com/Eppo-exp/sdk-common-jdk/pull/60