### PR TITLE
fix: Rename sonatype credentials var

### DIFF
--- a/.github/workflows/publish-sdk.yaml
+++ b/.github/workflows/publish-sdk.yaml
@@ -6,8 +6,8 @@ on:
 
 env:
   ANDROID_API_LEVEL: 33
-  ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
-  ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
+  ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
+  ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
   CI: true
 
 jobs:


### PR DESCRIPTION
I did this for `publish-snapshot` but forgot to do the same for `publish-sdk`