### PR TITLE
feat: Allow ignoring the cached configuration

### DIFF
--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -565,7 +565,7 @@ public class EppoClientTest {
   }
 
   @Test
-  public void testForceIgnoreCache() throws IOException, ExecutionException, InterruptedException {
+  public void testForceIgnoreCache() throws ExecutionException, InterruptedException {
     cacheUselessConfig();
     // Initialize with "useless" cache available.
     new EppoClient.Builder(DUMMY_API_KEY, ApplicationProvider.getApplicationContext())
@@ -587,7 +587,7 @@ public class EppoClientTest {
         .obfuscateConfig(true)
         .forceReinitialize(true)
         .offlineMode(false)
-        .ignoreCache(true)
+        .ignoreCachedConfiguration(true)
         .buildAndInitAsync()
         .get();
 
@@ -596,14 +596,18 @@ public class EppoClientTest {
     assertEquals(3.1415926, properAssignment, 0.0000001);
   }
 
-  private void cacheUselessConfig() throws IOException {
+  private void cacheUselessConfig() {
     ConfigCacheFile cacheFile =
         new ConfigCacheFile(
             ApplicationProvider.getApplicationContext(), safeCacheKey(DUMMY_API_KEY));
 
     Configuration config = new Configuration.Builder(uselessFlagConfigBytes).build();
 
-    cacheFile.getOutputStream().write(config.serializeFlagConfigToBytes());
+    try {
+      cacheFile.getOutputStream().write(config.serializeFlagConfigToBytes());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   private static final byte[] uselessFlagConfigBytes =

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -566,9 +566,6 @@ public class EppoClientTest {
 
   @Test
   public void testForceIgnoreCache() throws IOException, ExecutionException, InterruptedException {
-    // Note: This test requires hooks into the `CompletableFuture` returned by the builder to
-    // represent a more "immediate" processing of assignments
-
     cacheUselessConfig();
     // Initialize with "useless" cache available.
     new EppoClient.Builder(DUMMY_API_KEY, ApplicationProvider.getApplicationContext())
@@ -603,8 +600,6 @@ public class EppoClientTest {
     ConfigCacheFile cacheFile =
         new ConfigCacheFile(
             ApplicationProvider.getApplicationContext(), safeCacheKey(DUMMY_API_KEY));
-
-    cacheFile.delete(); // Deletes file if exists before creating a new one.
 
     Configuration config = new Configuration.Builder(uselessFlagConfigBytes).build();
 

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -121,7 +121,7 @@ public class EppoClient extends BaseEppoClient {
     private boolean forceReinitialize = false;
     private boolean offlineMode = false;
     private CompletableFuture<Configuration> initialConfiguration;
-    private boolean ignoreCache = false;
+    private boolean ignoreCachedConfiguration = false;
 
     // Assignment caching on by default. To disable, call `builder.assignmentCache(null);`
     private IAssignmentCache assignmentCache = new LRUAssignmentCache(100);
@@ -141,8 +141,8 @@ public class EppoClient extends BaseEppoClient {
       return this;
     }
 
-    public Builder ignoreCache(boolean ignoreCache) {
-      this.ignoreCache = ignoreCache;
+    public Builder ignoreCachedConfiguration(boolean ignoreCache) {
+      this.ignoreCachedConfiguration = ignoreCache;
       return this;
     }
 
@@ -217,7 +217,7 @@ public class EppoClient extends BaseEppoClient {
 
       // If the initial config was not set, use the ConfigurationStore's cache as the initial
       // config.
-      if (initialConfiguration == null && !ignoreCache) {
+      if (initialConfiguration == null && !ignoreCachedConfiguration) {
         initialConfiguration = configStore.loadConfigFromCache();
       }
 

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -121,6 +121,7 @@ public class EppoClient extends BaseEppoClient {
     private boolean forceReinitialize = false;
     private boolean offlineMode = false;
     private CompletableFuture<Configuration> initialConfiguration;
+    private boolean ignoreCache = false;
 
     // Assignment caching on by default. To disable, call `builder.assignmentCache(null);`
     private IAssignmentCache assignmentCache = new LRUAssignmentCache(100);
@@ -137,6 +138,11 @@ public class EppoClient extends BaseEppoClient {
 
     public Builder assignmentLogger(AssignmentLogger assignmentLogger) {
       this.assignmentLogger = assignmentLogger;
+      return this;
+    }
+
+    public Builder ignoreCache(boolean ignoreCache) {
+      this.ignoreCache = ignoreCache;
       return this;
     }
 
@@ -211,7 +217,7 @@ public class EppoClient extends BaseEppoClient {
 
       // If the initial config was not set, use the ConfigurationStore's cache as the initial
       // config.
-      if (initialConfiguration == null) {
+      if (initialConfiguration == null && !ignoreCache) {
         initialConfiguration = configStore.loadConfigFromCache();
       }
 


### PR DESCRIPTION
## Motivation and Context
There are certain circumstances when we want to suppress loading Configuration from the filesystem cache.

## Overview of Changes
- `IgnoreConfigurationCache` method.