### PR TITLE
fix(build): Allow signing build with in memory PGP keys

### DIFF
--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -104,6 +104,25 @@ spotless {
     }
 }
 
+signing {
+    if (System.getenv("GPG_PRIVATE_KEY") && System.getenv("GPG_PASSPHRASE")) {
+        // Use in-memory keys for CI builds
+        useInMemoryPgpKeys(
+                System.getenv("GPG_PRIVATE_KEY"),
+                System.getenv("GPG_PASSPHRASE")
+        )
+    } else if (project.hasProperty('signing.keyId') &&
+            project.hasProperty('signing.password') &&
+            project.hasProperty('signing.secretKeyRingFile')) {
+        // Use local GPG setup via gradle.properties for local builds
+        useGpgCmd()
+    } else {
+        throw new GradleException("No GPG signing configuration found. Please set up GPG_PRIVATE_KEY and GPG_PASSPHRASE for CI or configure signing in gradle.properties for local builds.")
+    }
+
+    sign publishing.publications // Sign all Maven publications
+}
+
 mavenPublishing {
     publishToMavenCentral(com.vanniktech.maven.publish.SonatypeHost.S01)
     signAllPublications()

--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -107,15 +107,7 @@ spotless {
 signing {
     if (System.getenv("GPG_PRIVATE_KEY") && System.getenv("GPG_PASSPHRASE")) {
         // Use in-memory keys for CI builds
-        useInMemoryPgpKeys(
-                System.getenv("GPG_PRIVATE_KEY"),
-                System.getenv("GPG_PASSPHRASE")
-        )
-    } else if (project.hasProperty('signing.keyId') &&
-            project.hasProperty('signing.password') &&
-            project.hasProperty('signing.secretKeyRingFile')) {
-        // Use local GPG setup via gradle.properties for local builds
-        useGpgCmd()
+        useInMemoryPgpKeys(System.env.GPG_PRIVATE_KEY, System.env.GPG_PASSPHRASE)
     }
 
     sign publishing.publications // Sign all Maven publications

--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -116,8 +116,6 @@ signing {
             project.hasProperty('signing.secretKeyRingFile')) {
         // Use local GPG setup via gradle.properties for local builds
         useGpgCmd()
-    } else {
-        throw new GradleException("No GPG signing configuration found. Please set up GPG_PRIVATE_KEY and GPG_PASSPHRASE for CI or configure signing in gradle.properties for local builds.")
     }
 
     sign publishing.publications // Sign all Maven publications

--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -123,6 +123,16 @@ signing {
     sign publishing.publications // Sign all Maven publications
 }
 
+// Make sure signing tasks only run if configured correctly
+tasks.withType(Sign) {
+    onlyIf {
+        (System.getenv("GPG_PRIVATE_KEY") && System.getenv("GPG_PASSPHRASE")) ||
+                (project.hasProperty('signing.keyId') &&
+                        project.hasProperty('signing.password') &&
+                        project.hasProperty('signing.secretKeyRingFile'))
+    }
+}
+
 mavenPublishing {
     publishToMavenCentral(com.vanniktech.maven.publish.SonatypeHost.S01)
     signAllPublications()


### PR DESCRIPTION
## Description

For local builds signing, we use the following in the `~/gradle/gradle.properties` file:

```
signing.keyId=12345678
signing.password=some_password
signing.secretKeyRingFile=/Users/yourusername/.gnupg/secring.gpg
```

However, for CI builds we use in-memory PGP keys from `GPG_PRIVATE_KEY` and `GPG_PASSPHRASE`. This used to work well, but since we moved to `com.vanniktech.maven.publish` it looks like this functionality broke CI release publishing.

This logic ensures that we can use one or the other depending on whether the env vars are present

## Testing
1. Local GPG
```
./gradlew eppo:signMavenPublication                                                                                                                                     
> Configure project :eppo
using local GPG

BUILD SUCCESSFUL in 593ms
29 actionable tasks: 2 executed, 27 up-to-date
```

2. In memory key:
```
GPG_PRIVATE_KEY=foo GPG_PASSPHRASE=bar ./gradlew eppo:signMavenPublication                                                                                              

> Configure project :eppo
using in memory signing keys

> Task :eppo:signMavenPublication FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':eppo:signMavenPublication'.
> Could not read PGP secret key

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.
```