### PR TITLE
chore: latest from the common package and move `/api` to baseUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ feature flagging and experimentation for Eppo customers. An API key is required 
 
 ```groovy
 dependencies {
-  implementation 'cloud.eppo:android-sdk:4.3.3'
+  implementation 'cloud.eppo:android-sdk:4.4.0'
 }
 
 dependencyResolutionManagement {

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ feature flagging and experimentation for Eppo customers. An API key is required 
 
 ```groovy
 dependencies {
-  implementation 'cloud.eppo:android-sdk:4.3.0'
+  implementation 'cloud.eppo:android-sdk:4.3.1'
 }
 
 dependencyResolutionManagement {

--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "cloud.eppo"
-version = "4.3.6"
+version = "4.4.0"
 
 android {
     buildFeatures.buildConfig true
@@ -68,7 +68,7 @@ ext.versions = [
 ]
 
 dependencies {
-    api 'cloud.eppo:sdk-common-jvm:3.5.4'
+    api 'cloud.eppo:sdk-common-jvm:3.6.0'
 
     implementation 'org.slf4j:slf4j-api:2.0.16'
 

--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "cloud.eppo"
-version = "4.3.1-SNAPSHOT"
+version = "4.3.1"
 
 android {
     buildFeatures.buildConfig true

--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -68,7 +68,7 @@ ext.versions = [
 ]
 
 dependencies {
-    api 'cloud.eppo:sdk-common-jvm:3.5.0'
+    api 'cloud.eppo:sdk-common-jvm:3.5.2'
 
     implementation 'org.slf4j:slf4j-api:2.0.16'
     implementation 'uk.uuid.slf4j:slf4j-android:2.0.16-0'

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -8,7 +8,6 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import cloud.eppo.BaseEppoClient;
-import cloud.eppo.Constants;
 import cloud.eppo.IConfigurationStore;
 import cloud.eppo.android.cache.LRUAssignmentCache;
 import cloud.eppo.android.exceptions.MissingApiKeyException;
@@ -34,9 +33,10 @@ public class EppoClient extends BaseEppoClient {
 
   private EppoClient(
       String apiKey,
-      String host,
       String sdkName,
       String sdkVersion,
+      @Deprecated @Nullable String host,
+      @Nullable String apiBaseUrl,
       @Nullable AssignmentLogger assignmentLogger,
       IConfigurationStore configurationStore,
       boolean isGracefulMode,
@@ -48,6 +48,7 @@ public class EppoClient extends BaseEppoClient {
         sdkName,
         sdkVersion,
         host,
+        apiBaseUrl,
         assignmentLogger,
         null,
         configurationStore,
@@ -65,11 +66,13 @@ public class EppoClient extends BaseEppoClient {
   public static EppoClient init(
       @NonNull Application application,
       @NonNull String apiKey,
-      @NonNull String host,
+      @Nullable String host,
+      @Nullable String apiBaseUrl,
       @Nullable AssignmentLogger assignmentLogger,
       boolean isGracefulMode) {
     return new Builder(apiKey, application)
         .host(host)
+        .apiBaseUrl(apiBaseUrl)
         .assignmentLogger(assignmentLogger)
         .isGracefulMode(isGracefulMode)
         .obfuscateConfig(DEFAULT_OBFUSCATE_CONFIG)
@@ -112,7 +115,8 @@ public class EppoClient extends BaseEppoClient {
   }
 
   public static class Builder {
-    @NonNull private String host = Constants.DEFAULT_BASE_URL;
+    private String host;
+    private String apiBaseUrl;
     private final Application application;
     private final String apiKey;
     @Nullable private AssignmentLogger assignmentLogger;
@@ -132,8 +136,13 @@ public class EppoClient extends BaseEppoClient {
       this.apiKey = apiKey;
     }
 
-    public Builder host(String host) {
+    public Builder host(@Nullable String host) {
       this.host = host;
+      return this;
+    }
+
+    public Builder apiBaseUrl(@Nullable String apiBaseUrl) {
+      this.apiBaseUrl = apiBaseUrl;
       return this;
     }
 
@@ -225,9 +234,10 @@ public class EppoClient extends BaseEppoClient {
       instance =
           new EppoClient(
               apiKey,
-              host,
               sdkName,
               sdkVersion,
+              host,
+              apiBaseUrl,
               assignmentLogger,
               configStore,
               isGracefulMode,

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -8,6 +8,7 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import cloud.eppo.BaseEppoClient;
+import cloud.eppo.Constants;
 import cloud.eppo.IConfigurationStore;
 import cloud.eppo.android.cache.LRUAssignmentCache;
 import cloud.eppo.android.exceptions.MissingApiKeyException;
@@ -25,7 +26,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class EppoClient extends BaseEppoClient {
   private static final String TAG = logTag(EppoClient.class);
-  private static final String DEFAULT_HOST = "https://fscdn.eppo.cloud";
   private static final boolean DEFAULT_IS_GRACEFUL_MODE = true;
   private static final boolean DEFAULT_OBFUSCATE_CONFIG = true;
 
@@ -111,7 +111,7 @@ public class EppoClient extends BaseEppoClient {
   }
 
   public static class Builder {
-    @NonNull private String host = DEFAULT_HOST;
+    @NonNull private String host = Constants.DEFAULT_BASE_URL;
     private final Application application;
     private final String apiKey;
     @Nullable private AssignmentLogger assignmentLogger;


### PR DESCRIPTION
towards FF-3558
🎟️ [FF-3558](https://linear.app/eppo/issue/FF-3558/unify-sdk-request-baseurl)

## Motivation and Context
Most, nearly all in fact, of the SDKs use a baseUrl of https://fscdn.eppo.cloud/api and endpoint constants of `/flag-config/v1/config` and `/flag-config/v1/bandits` for flag and bandit requests.

All of the SDKs need to follow the common convention in order for our cross-SDK testing tools (scenario testing, benchmarking) to work seamlessly.

