### PR TITLE
fix: allow offline init with unobfuscated config

### DIFF
--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "cloud.eppo"
-version = "4.3.5-SNAPSHOT"
+version = "4.3.5"
 
 android {
     buildFeatures.buildConfig true

--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "cloud.eppo"
-version = "4.3.4-SNAPSHOT"
+version = "4.3.5-SNAPSHOT"
 
 android {
     buildFeatures.buildConfig true

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -371,15 +371,15 @@ public class EppoClientTest {
 
   @Test
   public void testOfflineInit() throws IOException {
-    testOfflineInit("flags-v1.json");
+    testOfflineInitFromFile("flags-v1.json");
   }
 
   @Test
   public void testObfuscatedOfflineInit() throws IOException {
-    testOfflineInit("flags-v1-obfuscated.json");
+    testOfflineInitFromFile("flags-v1-obfuscated.json");
   }
 
-  public void testOfflineInit(String filepath) throws IOException {
+  public void testOfflineInitFromFile(String filepath) throws IOException {
     AssetManager assets = ApplicationProvider.getApplicationContext().getAssets();
 
     InputStream stream = assets.open(filepath);

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -175,13 +175,13 @@ public class EppoClient extends BaseEppoClient {
     public Builder initialConfiguration(byte[] initialFlagConfigResponse) {
       this.initialConfiguration =
           CompletableFuture.completedFuture(
-              Configuration.builder(initialFlagConfigResponse, true).build());
+              new Configuration.Builder(initialFlagConfigResponse).build());
       return this;
     }
 
     public Builder initialConfiguration(CompletableFuture<byte[]> initialFlagConfigResponse) {
       this.initialConfiguration =
-          initialFlagConfigResponse.thenApply(ic -> Configuration.builder(ic, true).build());
+          initialFlagConfigResponse.thenApply(ic -> new Configuration.Builder(ic).build());
       return this;
     }
 


### PR DESCRIPTION
fixes: FF-3751

## Motivation and Context
Due to the sensitive nature of the client configuration payload, the decision was made to support only obfuscated configuration in the Android SDK through its standard initialization method. This decision was made _prior_ to the introduction of the `format` field in `FlagConfigResponse`. This was short-sighted as

1. This is a popular development approach
2. The configuration payload now contains the `format` field which can be used to determine the format of the configuration.

## Changes
- migrated the client init entry points to call into the `Configuration.Builder` without forcing `isConfigObfuscated` to `true`
- tests

## Future work
- deprecated methods where `isConfigObfuscated` can be provided in the jvm-common-sdk