### PR TITLE
feat: Allowing polling in Android mobile client

### DIFF
--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "cloud.eppo"
-version = "4.4.1-SNAPSHOT"
+version = "4.5.0-SNAPSHOT"
 
 android {
     buildFeatures.buildConfig true
@@ -68,7 +68,7 @@ ext.versions = [
 ]
 
 dependencies {
-    api 'cloud.eppo:sdk-common-jvm:3.7.0-SNAPSHOT'
+    api 'cloud.eppo:sdk-common-jvm:3.7.0'
 
     implementation 'org.slf4j:slf4j-api:2.0.16'
 

--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -68,7 +68,7 @@ ext.versions = [
 ]
 
 dependencies {
-    api 'cloud.eppo:sdk-common-jvm:3.6.0'
+    api 'cloud.eppo:sdk-common-jvm:3.7.0-SNAPSHOT'
 
     implementation 'org.slf4j:slf4j-api:2.0.16'
 

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -79,6 +80,7 @@ public class EppoClientTest {
       TEST_HOST_BASE + (TEST_BRANCH != null ? "/b/" + TEST_BRANCH : "");
 
   private static final String INVALID_HOST = "https://thisisabaddomainforthistest.com";
+  private static final byte[] EMPTY_CONFIG = "{\"flags\":{}}".getBytes();
   private final ObjectMapper mapper = new ObjectMapper().registerModule(module());
   @Mock AssignmentLogger mockAssignmentLogger;
   @Mock EppoHttpClient mockHttpClient;
@@ -295,6 +297,44 @@ public class EppoClientTest {
 
     // Initialize and no exception should be thrown.
     clientBuilder.buildAndInitAsync().get();
+  }
+
+  @Test
+  public void testPollingClient() throws ExecutionException, InterruptedException {
+    // Set up a changing response from the "server"
+    EppoHttpClient mockHttpClient = mock(EppoHttpClient.class);
+
+    // Mock sync get
+    when(mockHttpClient.get(anyString())).thenReturn(EMPTY_CONFIG);
+
+    // Mock async get
+    CompletableFuture<byte[]> emptyResponse = CompletableFuture.completedFuture(EMPTY_CONFIG);
+    when(mockHttpClient.getAsync(anyString())).thenReturn(emptyResponse);
+
+    setBaseClientHttpClientOverrideField(mockHttpClient);
+
+    long pollingInterval = 50;
+
+    EppoClient.Builder clientBuilder =
+        new EppoClient.Builder(DUMMY_API_KEY, ApplicationProvider.getApplicationContext())
+            .forceReinitialize(true)
+            .pollingEnabled(true)
+            .pollingIntervalMs(pollingInterval)
+            .isGracefulMode(false);
+
+    // Initialize and no exception should be thrown.
+    EppoClient eppoClient = clientBuilder.buildAndInitAsync().get();
+
+    verify(mockHttpClient, times(1)).getAsync(anyString());
+    assertFalse(eppoClient.getBooleanAssignment("bool_flag", "subject1", false));
+
+    // Now, return the boolean flag config (bool_flag = true)
+    when(mockHttpClient.get(anyString())).thenReturn(BOOL_FLAG_CONFIG);
+    // Wait the polling interval
+    Thread.sleep(pollingInterval * 2);
+
+    verify(mockHttpClient, atLeast(1)).get(anyString());
+    assertTrue(eppoClient.getBooleanAssignment("bool_flag", "subject1", false));
   }
 
   @Test
@@ -949,4 +989,40 @@ public class EppoClientTest {
       throw new RuntimeException(e);
     }
   }
+
+  private static final byte[] BOOL_FLAG_CONFIG =
+      ("{\n"
+              + "  \"createdAt\": \"2024-04-17T19:40:53.716Z\",\n"
+              + "  \"format\": \"SERVER\",\n"
+              + "  \"environment\": {\n"
+              + "    \"name\": \"Test\"\n"
+              + "  },\n"
+              + "  \"flags\": {\n"
+              + "    \"9a2025738dde19ff44cd30b9d2967000\": {\n"
+              + "      \"key\": \"9a2025738dde19ff44cd30b9d2967000\",\n"
+              + "      \"enabled\": true,\n"
+              + "      \"variationType\": \"BOOLEAN\",\n"
+              + "      \"variations\": {\n"
+              + "        \"b24=\": {\n"
+              + "          \"key\": \"b24=\",\n"
+              + "          \"value\": \"dHJ1ZQ==\"\n"
+              + "        }\n"
+              + "      },\n"
+              + "      \"allocations\": [\n"
+              + "        {\n"
+              + "          \"key\": \"b24=\",\n"
+              + "          \"doLog\": true,\n"
+              + "          \"splits\": [\n"
+              + "            {\n"
+              + "              \"variationKey\": \"b24=\",\n"
+              + "              \"shards\": []\n"
+              + "            }\n"
+              + "          ]\n"
+              + "        }\n"
+              + "      ],\n"
+              + "      \"totalShards\": 10000\n"
+              + "    }\n"
+              + "  }\n"
+              + "}")
+          .getBytes();
 }

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -313,13 +313,13 @@ public class EppoClientTest {
 
     setBaseClientHttpClientOverrideField(mockHttpClient);
 
-    long pollingInterval = 50;
+    long pollingIntervalMs = 50;
 
     EppoClient.Builder clientBuilder =
         new EppoClient.Builder(DUMMY_API_KEY, ApplicationProvider.getApplicationContext())
             .forceReinitialize(true)
             .pollingEnabled(true)
-            .pollingIntervalMs(pollingInterval)
+            .pollingIntervalMs(pollingIntervalMs)
             .isGracefulMode(false);
 
     // Initialize and no exception should be thrown.
@@ -331,7 +331,7 @@ public class EppoClientTest {
     // Now, return the boolean flag config (bool_flag = true)
     when(mockHttpClient.get(anyString())).thenReturn(BOOL_FLAG_CONFIG);
     // Wait the polling interval
-    Thread.sleep(pollingInterval * 2);
+    Thread.sleep(pollingIntervalMs * 2);
 
     verify(mockHttpClient, atLeast(1)).get(anyString());
     assertTrue(eppoClient.getBooleanAssignment("bool_flag", "subject1", false));

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -131,6 +131,11 @@ public class EppoClient extends BaseEppoClient {
     private boolean ignoreCachedConfiguration = false;
     private boolean pollingEnabled = false;
     private long pollingIntervalMs = DEFAULT_POLLING_INTERVAL_MS;
+
+    /**
+     * -1 causes the default jitter to be used (which is a % of the interval, not a constant
+     * amount).
+     */
     private long pollingJitterMs = -1;
 
     // Assignment caching on by default. To disable, call `builder.assignmentCache(null);`
@@ -222,7 +227,11 @@ public class EppoClient extends BaseEppoClient {
       return this;
     }
 
-    /** */
+    /**
+     * Sets the amount of jitter to use when scheduling next poll call. The jitter is the maximum
+     * difference between the specified `pollingIntervalMs` and the effective interval used for each
+     * time the polling waits for the next call.
+     */
     public Builder pollingJitterMs(long pollingJitterMs) {
       this.pollingJitterMs = pollingJitterMs;
       return this;
@@ -381,7 +390,9 @@ public class EppoClient extends BaseEppoClient {
 
   public void resumePolling() {
     if (pollingIntervalMs <= 0) {
-      Log.w(TAG, "resumePolling called, but polling was not started.");
+      Log.w(
+          TAG,
+          "resumePolling called, but polling was not started due to invalid polling interval.");
       return;
     }
 

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -133,7 +133,7 @@ public class EppoClient extends BaseEppoClient {
     private boolean ignoreCachedConfiguration = false;
     private boolean pollingEnabled = false;
     private long pollingIntervalMs = DEFAULT_POLLING_INTERVAL_MS;
-    private long pollingJitterMs = DEFAULT_POLLING_INTERVAL_MS / DEFAULT_JITTER_INTERVAL_RATIO;
+    private long pollingJitterMs = -1;
 
     // Assignment caching on by default. To disable, call `builder.assignmentCache(null);`
     private IAssignmentCache assignmentCache = new LRUAssignmentCache(100);
@@ -305,6 +305,9 @@ public class EppoClient extends BaseEppoClient {
       // Start polling, if configured.
       if (pollingEnabled && pollingIntervalMs > 0) {
         Log.d(TAG, "Starting poller");
+        if (pollingJitterMs < 0) {
+          pollingJitterMs = pollingIntervalMs / DEFAULT_JITTER_INTERVAL_RATIO;
+        }
         instance.startPolling(pollingIntervalMs, pollingJitterMs);
       }
 

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -308,6 +308,7 @@ public class EppoClient extends BaseEppoClient {
         if (pollingJitterMs < 0) {
           pollingJitterMs = pollingIntervalMs / DEFAULT_JITTER_INTERVAL_RATIO;
         }
+
         instance.startPolling(pollingIntervalMs, pollingJitterMs);
       }
 
@@ -364,6 +365,7 @@ public class EppoClient extends BaseEppoClient {
   }
 
   private long pollingIntervalMs, pollingJitterMs;
+
   protected void stopPolling() {
     super.stopPolling();
   }
@@ -385,6 +387,6 @@ public class EppoClient extends BaseEppoClient {
       return;
     }
 
-    this.startPolling(pollingIntervalMs,pollingJitterMs);
+    this.startPolling(pollingIntervalMs, pollingJitterMs);
   }
 }

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -19,7 +19,6 @@ import cloud.eppo.api.EppoValue;
 import cloud.eppo.api.IAssignmentCache;
 import cloud.eppo.logging.AssignmentLogger;
 import cloud.eppo.ufc.dto.VariationType;
-import java.util.Timer;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
@@ -33,7 +32,6 @@ public class EppoClient extends BaseEppoClient {
   private static final long DEFAULT_JITTER_INTERVAL_RATIO = 10;
 
   @Nullable private static EppoClient instance;
-  private Timer pollTimer;
 
   private EppoClient(
       String apiKey,
@@ -387,6 +385,6 @@ public class EppoClient extends BaseEppoClient {
       return;
     }
 
-    this.startPolling(pollingIntervalMs, pollingJitterMs);
+    super.startPolling(pollingIntervalMs, pollingJitterMs);
   }
 }

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -363,11 +363,28 @@ public class EppoClient extends BaseEppoClient {
     }
   }
 
+  private long pollingIntervalMs, pollingJitterMs;
   protected void stopPolling() {
     super.stopPolling();
   }
 
   protected void startPolling(long pollingIntervalMs, long pollingJitterMs) {
+    // Store the polling params for resuming later.
+    this.pollingIntervalMs = pollingIntervalMs;
+    this.pollingJitterMs = pollingJitterMs;
     super.startPolling(pollingIntervalMs, pollingJitterMs);
+  }
+
+  public void pausePolling() {
+    super.stopPolling();
+  }
+
+  public void resumePolling() {
+    if (pollingIntervalMs <= 0) {
+      Log.w(TAG, "resumePolling called, but polling was not started.");
+      return;
+    }
+
+    this.startPolling(pollingIntervalMs,pollingJitterMs);
   }
 }

--- a/example/src/main/java/cloud/eppo/androidexample/SecondActivity.java
+++ b/example/src/main/java/cloud/eppo/androidexample/SecondActivity.java
@@ -94,4 +94,30 @@ public class SecondActivity extends AppCompatActivity {
     assignmentLog.append(message + "\n\n");
     assignmentLogScrollView.post(() -> assignmentLogScrollView.fullScroll(View.FOCUS_DOWN));
   }
+
+  // Tie into the activity's lifecycle and pause/resume polling where appropriate.
+
+  @Override
+  public void onStop() {
+    super.onStop();
+    EppoClient.getInstance().pausePolling();
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    EppoClient.getInstance().pausePolling();
+  }
+
+  @Override
+  public void onStart() {
+    super.onStart();
+    EppoClient.getInstance().resumePolling();
+  }
+
+  @Override
+  public void onResume() {
+    super.onResume();
+    EppoClient.getInstance().resumePolling();
+  }
 }

--- a/example/src/main/java/cloud/eppo/androidexample/SecondActivity.java
+++ b/example/src/main/java/cloud/eppo/androidexample/SecondActivity.java
@@ -98,21 +98,9 @@ public class SecondActivity extends AppCompatActivity {
   // Tie into the activity's lifecycle and pause/resume polling where appropriate.
 
   @Override
-  public void onStop() {
-    super.onStop();
-    EppoClient.getInstance().pausePolling();
-  }
-
-  @Override
   public void onPause() {
     super.onPause();
     EppoClient.getInstance().pausePolling();
-  }
-
-  @Override
-  public void onStart() {
-    super.onStart();
-    EppoClient.getInstance().resumePolling();
   }
 
   @Override


### PR DESCRIPTION
## Motivation and Context
Getting periodic flag configuration updates to mobile app SDKs has not been a priority since the session lengths are generally pretty low. To bring more feature parity across the Java SDKs, we seek to expose polling functionality and configuration options to the android SDK

## Description of Changes
- expose polling params in the client builder
- start polling after init, if polling is enabled in the builder
- surface pause/resume methods so polling can hook into the application/activity's lifecycle

## How has this been documented
[FF-3923](https://linear.app/eppo/issue/FF-3923/[docs]-update-android-documentation)
[eppo-docs#588](https://github.com/Eppo-exp/eppo-docs/pull/588-detailing-polling-configuration)