### PR TITLE
feat: Make loadConfiguration public

### DIFF
--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "cloud.eppo"
-version = "4.5.0-SNAPSHOT"
+version = "4.6.0"
 
 android {
     buildFeatures.buildConfig true

--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "cloud.eppo"
-version = "4.6.0"
+version = "4.6.0-SNAPSHOT"
 
 android {
     buildFeatures.buildConfig true

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -117,11 +117,13 @@ public class EppoClient extends BaseEppoClient {
   }
 
   /** (Re)loads flag and experiment configuration from the API server. */
+  @Override
   public void loadConfiguration() {
     super.loadConfiguration();
   }
 
   /** Asynchronously (re)loads flag and experiment configuration from the API server. */
+  @Override
   public CompletableFuture<Void> loadConfigurationAsync() {
     return super.loadConfigurationAsync();
   }

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -116,6 +116,16 @@ public class EppoClient extends BaseEppoClient {
         flagKey, subjectKey, subjectAttributes, defaultValue, expectedType);
   }
 
+  /** (Re)loads flag and experiment configuration from the API server. */
+  public void loadConfiguration() {
+    super.loadConfiguration();
+  }
+
+  /** Asynchronously (re)loads flag and experiment configuration from the API server. */
+  public CompletableFuture<Void> loadConfigurationAsync() {
+    return super.loadConfigurationAsync();
+  }
+
   public static class Builder {
     private String host;
     private String apiBaseUrl;


### PR DESCRIPTION
Fixes FF-4031

## Motivation and Context

On mobile applications, it is useful to reload the configuration on-demand since polling is not typically employed.

## Description of Change
Override the `loadConfiguration` and `loadConfigurationAsync` methods on the `EppoClient`, delegating to the super class methods.

## How has this been tested
New unit tests