### PR TITLE
minimal implementation for listening for config updates

### DIFF
--- a/eppo/src/main/java/cloud/eppo/android/AndroidConfigurationStore.java
+++ b/eppo/src/main/java/cloud/eppo/android/AndroidConfigurationStore.java
@@ -1,0 +1,10 @@
+package cloud.eppo.android;
+
+import java.util.concurrent.CompletableFuture;
+
+import cloud.eppo.IConfigurationStore;
+import cloud.eppo.api.Configuration;
+
+public interface AndroidConfigurationStore extends IConfigurationStore {
+  CompletableFuture<Configuration> loadConfigFromCache();
+}

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationChangeListener.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationChangeListener.java
@@ -1,0 +1,5 @@
+package cloud.eppo.android;
+
+public interface ConfigurationChangeListener {
+  void onConfigurationChanged();
+}

--- a/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
+++ b/eppo/src/main/java/cloud/eppo/android/ConfigurationStore.java
@@ -6,7 +6,6 @@ import android.app.Application;
 import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import cloud.eppo.IConfigurationStore;
 import cloud.eppo.android.util.Utils;
 import cloud.eppo.api.Configuration;
 import java.io.IOException;
@@ -14,7 +13,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.concurrent.CompletableFuture;
 
-public class ConfigurationStore implements IConfigurationStore {
+public class ConfigurationStore implements AndroidConfigurationStore {
 
   private static final String TAG = logTag(ConfigurationStore.class);
   private final ConfigCacheFile cacheFile;

--- a/eppo/src/main/java/cloud/eppo/android/ListenableConfigurationStore.java
+++ b/eppo/src/main/java/cloud/eppo/android/ListenableConfigurationStore.java
@@ -1,0 +1,35 @@
+package cloud.eppo.android;
+
+import java.util.concurrent.CompletableFuture;
+
+import androidx.annotation.NonNull;
+import cloud.eppo.api.Configuration;
+
+public class ListenableConfigurationStore implements AndroidConfigurationStore {
+
+  private final AndroidConfigurationStore store;
+  private final ConfigurationChangeListener listener;
+
+  public ListenableConfigurationStore(AndroidConfigurationStore store, ConfigurationChangeListener listener) {
+    this.store = store;
+    this.listener = listener;
+  }
+
+  @NonNull
+  @Override
+  public Configuration getConfiguration() {
+    return store.getConfiguration();
+  }
+
+  @Override
+  public CompletableFuture<Void> saveConfiguration(Configuration configuration) {
+    return store
+        .saveConfiguration(configuration)
+        .thenRun(listener::onConfigurationChanged);
+  }
+
+  @Override
+  public CompletableFuture<Configuration> loadConfigFromCache() {
+    return store.loadConfigFromCache();
+  }
+}


### PR DESCRIPTION
I had a need to listen for feature flag updates as part of our Eppo client integration. To do that, I wait for config updates and re-fetch the feature flag in downstream observable subscribers. I think this is already on your roadmap, but here's what's working for me so far. I tried to make as few changes as I could. If this is something you'd be interested in merging, I can update with tests. If not, no worries and I look forward to the official feature support :)