### PR TITLE
Make EppoClient.Builder.configStore() public

### DIFF
--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -220,7 +220,7 @@ public class EppoClient extends BaseEppoClient {
       return this;
     }
 
-    Builder configStore(ConfigurationStore configStore) {
+    public Builder configStore(ConfigurationStore configStore) {
       this.configStore = configStore;
       return this;
     }


### PR DESCRIPTION
## Motivation and Context
[//]: #  I want to keep showing archived feature flags. I will make a custom `ConfigurationStore` to do that and will merge the last-seen feature flag there.

## Description
[//]: # Make `cloud.eppo.android.EppoClient.Builder.configStore()` public so I can customize `ConfigurationStore`

## How has this been documented?
[//]: # I didn't.

## How has this been tested?
[//]: # I didn't test this because it has no impact on the product.
