### PR TITLE
publish with jreleaser wip

### DIFF
--- a/.github/workflows/publish-sdk.yaml
+++ b/.github/workflows/publish-sdk.yaml
@@ -6,8 +6,8 @@ on:
 
 env:
   ANDROID_API_LEVEL: 33
-  ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
-  ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
+  MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+  MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
   CI: true
 
 jobs:
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -35,6 +37,12 @@ jobs:
 
       - name: Publish Release artifact
         run: ./gradlew eppo:assemble eppo:publish -Prelease --no-daemon
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Deploy to Maven Central
+        run: ./gradlew jreleaserDeploy
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -2,11 +2,11 @@ name: Publish SDK Snapshot artifact
 
 on:
   push:
-    branches: [main]
+    branches: [main, tp/*]
 
 env:
-  ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
-  ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
+  MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+  MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
   CI: true
 
 jobs:

--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'com.android.library'
     id 'maven-publish'
     id "com.vanniktech.maven.publish" version "0.31.0"
-    id 'signing'
+    id 'org.jreleaser' version '1.18.0'
     id "com.diffplug.spotless" version "7.0.3"
 }
 
@@ -104,15 +104,6 @@ spotless {
     }
 }
 
-signing {
-    if (System.getenv("GPG_PRIVATE_KEY") && System.getenv("GPG_PASSPHRASE")) {
-        // Use in-memory keys for CI builds
-        useInMemoryPgpKeys(System.env.GPG_PRIVATE_KEY, System.env.GPG_PASSPHRASE)
-    }
-
-    sign publishing.publications // Sign all Maven publications
-}
-
 // Make sure signing tasks only run if configured correctly
 tasks.withType(Sign) {
     onlyIf {
@@ -151,6 +142,38 @@ mavenPublishing {
         }
     }
 }
+
+jreleaser {
+  signing {
+    active = 'ALWAYS'
+    armored = true
+    verify = false
+  }
+  deploy {
+    maven {
+      mavenCentral {
+        'release-deploy' {
+          active = 'RELEASE'
+          url = 'https://central.sonatype.com/api/v1/publisher'
+          stagingRepository('build/staging-deploy')
+        }
+      }
+      nexus2 {
+        'snapshot-deploy' {
+          active = 'SNAPSHOT'
+          snapshotUrl = 'https://central.sonatype.com/repository/maven-snapshots'
+          url = 'https://central.sonatype.com/repository/maven-snapshots'
+          applyMavenCentralRules = true
+          snapshotSupported = true
+          closeRepository = true
+          releaseRepository = true
+          stagingRepository('build/staging-deploy')
+        }
+      }
+    }
+  }
+}
+
 
 // Custom task to ensure we can conditionally publish either a release or snapshot artifact
 // based on a command line switch. See github workflow files for more details on usage.


### PR DESCRIPTION
_Eppo Internal:_
Fixes FFL-95

## Motivation and Context
Maven OSSRH is being sunset, so we need to migrate to publishing via the Maven Central Portal.
See also
https://github.com/Eppo-exp/java-server-sdk/pull/120
https://github.com/Eppo-exp/sdk-common-jdk/pull/124