### PR TITLE
Include api level 28 in test matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        api-level: [26, 31, 34]
+        api-level: [26, 28, 31, 34]
       # Allow other tests to continue if one fails
       fail-fast: false
 


### PR DESCRIPTION
_Eppo Internal:_

[//]: #  (Link to the issue corresponding to this chunk of work)
:tickets: [FFL-432 - Include API Version 28 (Android 9) In Matrix Test](https://datadoghq.atlassian.net/browse/FFL-432?atlOrigin=eyJpIjoiOTU4ZTE5NzFlNjY5NGViZmJhZmIwNmUxYWRlYmM5NzciLCJwIjoiaiJ9)
🗨️ Relevant slack: ["...Android 9 devices..."](https://eppo-group.slack.com/archives/C08B4L9G2N9/p1752526190798449)

## Motivation and Context
We'd like to explicitly test Android 9

## Description
Add API Version 28 to test matrix

## How has this been documented?
_n/a_

## How has this been tested?
The tests themselves!
<img width="210" height="30" alt="image" src="https://github.com/user-attachments/assets/3d7c27eb-9358-4e50-932e-b5ad81aa3af2" />

