### PR TITLE
fix: deobfuscate extraLogging payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ feature flagging and experimentation for Eppo customers. An API key is required 
 
 ```groovy
 dependencies {
-  implementation 'cloud.eppo:android-sdk:4.10.1'
+  implementation 'cloud.eppo:android-sdk:4.10.2'
 }
 
 dependencyResolutionManagement {

--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "cloud.eppo"
-version = "4.10.2-SNAPSHOT"
+version = "4.10.2"
 
 android {
     buildFeatures.buildConfig true

--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "cloud.eppo"
-version = "4.10.1-SNAPSHOT"
+version = "4.10.2-SNAPSHOT"
 
 android {
     buildFeatures.buildConfig true
@@ -68,7 +68,7 @@ ext.versions = [
 ]
 
 dependencies {
-    api 'cloud.eppo:sdk-common-jvm:3.12.1'
+    api 'cloud.eppo:sdk-common-jvm:3.12.2'
 
     implementation 'org.slf4j:slf4j-api:2.0.17'
 


### PR DESCRIPTION
_Datadog Internal:_

:tickets: Fixes [FFL-608](https://datadoghq.atlassian.net/browse/FFL-608)

## Motivation and Context

When using obfuscated configurations in the Eppo SDK, the `extraLogging` field in flag evaluation results was not being deobfuscated, unlike other fields such as `allocationKey` and `variation` data. This inconsistency meant that when `isConfigObfuscated` was true, the `extraLogging` field would remain base64-encoded, breaking the holdouts feature which relies on this payload

## Description
- This bug was fixed in the java common SDK in [143](https://github.com/Eppo-exp/sdk-common-jdk/pull/143)
- here, we simply upgrade the dependency
