### PR TITLE
chore: bump for snapshot version

### DIFF
--- a/eppo/build.gradle
+++ b/eppo/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "cloud.eppo"
-version = "4.11.1"
+version = "4.11.1-SNAPSHOT"
 
 android {
     buildFeatures.buildConfig true


### PR DESCRIPTION
to be merged **after** `v4.11.0` is published. 👉  See #225 