### PR TITLE
feat: add oneShot parameter for initialization configuration change listener

### DIFF
--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -397,7 +397,8 @@ public class EppoClientTest {
   }
 
   @Test
-  public void testConfigurationChangeListenerOneShot() throws ExecutionException, InterruptedException {
+  public void testConfigurationChangeListenerOneShot()
+      throws ExecutionException, InterruptedException {
     List<Configuration> received = new ArrayList<>();
 
     // Set up a changing response from the "server"

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -175,13 +175,10 @@ public class EppoClient extends BaseEppoClient {
 
       @Override
       public void accept(Configuration config) {
-        try {
-          delegate.accept(config);
-        } finally {
-          if (unsubscriber != null) {
-            unsubscriber.run();
-          }
+        if (unsubscriber != null) {
+          unsubscriber.run();
         }
+        delegate.accept(config);
       }
     }
 

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -158,7 +158,8 @@ public class EppoClient extends BaseEppoClient {
     @Nullable private Consumer<Configuration> configChangeCallback;
 
     /**
-     * Wrapper for one-shot configuration change callbacks that auto-unsubscribes after first invocation.
+     * Wrapper for one-shot configuration change callbacks that auto-unsubscribes after first
+     * invocation.
      */
     private static class OneShotConfigCallback implements Consumer<Configuration> {
       private final Consumer<Configuration> delegate;
@@ -290,11 +291,15 @@ public class EppoClient extends BaseEppoClient {
 
     /**
      * Registers a callback for when a new configuration is applied to the `EppoClient` instance.
+     *
      * @param configChangeCallback The callback to invoke when configuration changes
-     * @param oneShot If true, the callback will be automatically unsubscribed after the first invocation
+     * @param oneShot If true, the callback will be automatically unsubscribed after the first
+     *     invocation
      */
-    public Builder onConfigurationChange(Consumer<Configuration> configChangeCallback, boolean oneShot) {
-      this.configChangeCallback = oneShot ? new OneShotConfigCallback(configChangeCallback) : configChangeCallback;
+    public Builder onConfigurationChange(
+        Consumer<Configuration> configChangeCallback, boolean oneShot) {
+      this.configChangeCallback =
+          oneShot ? new OneShotConfigCallback(configChangeCallback) : configChangeCallback;
       return this;
     }
 


### PR DESCRIPTION
_Eppo Internal:_
:tickets: Fixes FFL-1683

## Motivation and Context

Previously, when registering a configuration change callback via the Builder's `onConfigurationChange()` method, there was no way to unsubscribe from these notifications. The callback would continue to fire for every configuration change (initialization, manual `loadConfiguration()` calls, and polling updates) for the lifetime of the EppoClient instance.

This is problematic for initialization scenarios where developers only want to be notified once when the initial configuration is loaded, not on subsequent updates. Without an unsubscribe mechanism, developers would receive unwanted callbacks during polling or manual reloads.

While `BaseEppoClient.onConfigurationChange()` already returns an unsubscribe `Runnable`, the Android SDK wrapper wasn't capturing or exposing this functionality, making it impossible to unsubscribe from the Builder-registered callback.

Because we are building the Android client with a `Builder`, we don't have a clean vector to return the unsubscribe runnable without breaking the Builder convention or introducing a breaking change to the API. **In addition to this change, we can add an `unsubscribe(listener)` to the BaseEppoClient to allow unsubscribing.**


## Description

This PR adds an optional `oneShot` boolean parameter to the Builder's `onConfigurationChange()` method. When `oneShot=true`, the callback automatically unsubscribes itself after the first invocation, making it perfect for initialization scenarios.

### Implementation Details

**OneShotConfigCallback Wrapper Class** (`EppoClient.java:160-185`):
**Builder Method Overload** (`EppoClient.java:291-302`):
**Initialization Logic** (`EppoClient.java:354-360`):

## How has this been documented?

**Code Documentation**
TODO: Customer Comms

## How has this been tested?

**New Tesst**