### PR TITLE
feat(build): set up two-module structure for framework/batteries split

### DIFF
--- a/eppo-android-common/build.gradle
+++ b/eppo-android-common/build.gradle
@@ -10,31 +10,27 @@ group = "cloud.eppo"
 version = "4.12.1"
 
 android {
-    buildFeatures.buildConfig true
+    buildFeatures.buildConfig false
     compileSdk 34
 
     defaultConfig {
-        namespace "cloud.eppo.android"
+        // Use a different namespace to avoid conflicts with the framework module
+        // The code still uses cloud.eppo.android packages, but the Android namespace is different
+        namespace "cloud.eppo.android.common"
         minSdk 26
         targetSdk 34
-
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
     }
 
     buildTypes {
-        def EPPO_VERSION = "EPPO_VERSION"
-
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-            buildConfigField "String", EPPO_VERSION, "\"${project.properties.get("version")}\""
             matchingFallbacks = ['release']
         }
 
         debug {
             minifyEnabled false
-            buildConfigField "String", EPPO_VERSION, "\"${project.properties.get("version")}\""
             matchingFallbacks = ['debug']
         }
     }
@@ -52,40 +48,14 @@ android {
     }
 }
 
-ext {}
-ext.versions = [
-    "junit": "4.13.2",
-    "mockito": "5.14.2",
-    "roboelectric": "4.12+",
-    "androidx_junit": "1.2.1",
-    "androidx_test_core": "1.6.1",
-    "androidx_runner": "1.6.2",
-    "androidx_core": "1.13.1",
-    "gson": "2.9.1",
-    "okhttp": "4.12.0",
-    "commonsio": "2.17.0",
-    "semver": "0.10.2"
-]
-
 dependencies {
-    api 'cloud.eppo:sdk-common-jvm:3.13.1'
+    // API dependency on framework (for compilation)
+    api project(':eppo')
 
-    implementation 'org.slf4j:slf4j-api:2.0.17'
-
-    implementation "androidx.core:core:${versions.androidx_core}"
-    implementation "com.squareup.okhttp3:okhttp:${versions.okhttp}"
-    implementation "com.github.zafarkhaja:java-semver:${versions.semver}"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.19.1"
-
-    testImplementation "junit:junit:${versions.junit}"
-    testImplementation "commons-io:commons-io:${versions.commonsio}"
-    testImplementation "org.mockito:mockito-android:${versions.mockito}"
-    testImplementation "org.robolectric:robolectric:${versions.roboelectric}"
-    androidTestImplementation "org.mockito:mockito-android:${versions.mockito}"
-    androidTestImplementation "androidx.test.ext:junit:${versions.androidx_junit}"
-    androidTestImplementation "androidx.test:core:${versions.androidx_test_core}"
-    androidTestImplementation "androidx.test:runner:${versions.androidx_runner}"
-    androidTestImplementation "commons-io:commons-io:${versions.commonsio}"
+    // These will be added in PR4 when we add default implementations
+    // implementation 'cloud.eppo:eppo-sdk-common:4.0.0-SNAPSHOT'
+    // implementation "com.squareup.okhttp3:okhttp:4.12.0"
+    // implementation "com.fasterxml.jackson.core:jackson-databind:2.19.1"
 }
 
 spotless {
@@ -123,14 +93,15 @@ tasks.withType(Sign) {
     }
 }
 
+// For backward compatibility, keep same artifact ID
 mavenPublishing {
     publishToMavenCentral(com.vanniktech.maven.publish.SonatypeHost.CENTRAL_PORTAL)
     signAllPublications()
-    coordinates("cloud.eppo", "android-sdk-framework", project.version)
+    coordinates("cloud.eppo", "android-sdk", project.version)
 
     pom {
-        name = 'Eppo Android Framework'
-        description = 'Eppo Android SDK Framework - requires HTTP and parser implementations'
+        name = 'Eppo Android'
+        description = 'Eppo Android SDK - batteries-included with OkHttp and Jackson'
         url = 'https://github.com/Eppo-exp/android-sdk'
         licenses {
             license {

--- a/eppo-android-common/consumer-rules.pro
+++ b/eppo-android-common/consumer-rules.pro
@@ -1,0 +1,2 @@
+# Consumer ProGuard rules for eppo-android-common (batteries-included)
+# These rules are included in apps that use this library

--- a/eppo-android-common/src/main/AndroidManifest.xml
+++ b/eppo-android-common/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+</manifest>

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'com.google.android.material:material:1.12.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
-    implementation project(path: ':eppo')
+    implementation project(path: ':eppo-android-common')
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,3 +19,4 @@ dependencyResolutionManagement {
 rootProject.name = "Eppo SDK"
 include ':example'
 include ':eppo'
+include ':eppo-android-common'


### PR DESCRIPTION
## Summary

Sets up the two-module structure for the v4 SDK upgrade:
- `eppo/` - Framework module (publishes as `android-sdk-framework`)
- `eppo-android-common/` - Batteries-included module (publishes as `android-sdk`)

## Changes

- Created `eppo-android-common/` module directory structure
- Updated `settings.gradle` to include both modules
- Changed `eppo` artifact ID to `android-sdk-framework`
- Configured publishing for both artifacts

## Test Plan

- [ ] Build both modules: `./gradlew assemble`
- [ ] Verify framework module publishes without OkHttp/Jackson in final artifact
- [ ] Verify batteries-included module bundles framework code

## Part of v4 SDK Upgrade

This is PR 1 of the v4 upgrade series. See AGENT_PROMPT.md for full context.