### PR TITLE
Updates for Configuration Generification

### DIFF
--- a/android-sdk-framework/src/androidTest/java/cloud/eppo/android/framework/EppoClientPollingTest.java
+++ b/android-sdk-framework/src/androidTest/java/cloud/eppo/android/framework/EppoClientPollingTest.java
@@ -1,16 +1,24 @@
 package cloud.eppo.android.framework;
 
 import static cloud.eppo.android.framework.util.Utils.logTag;
+import static cloud.eppo.android.framework.util.Utils.safeCacheKey;
 import static org.junit.Assert.assertNotNull;
 
+import android.app.Application;
 import android.util.Log;
 import androidx.test.core.app.ApplicationProvider;
+
+import cloud.eppo.android.framework.storage.CachingConfigurationStore;
+import cloud.eppo.android.framework.storage.ConfigurationCodec;
+import cloud.eppo.android.framework.storage.FileBackedConfigStore;
 import cloud.eppo.api.Configuration;
 import cloud.eppo.http.EppoConfigurationClient;
 import cloud.eppo.parser.ConfigurationParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+
+import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -27,12 +35,34 @@ public class EppoClientPollingTest {
   private static final String TAG = logTag(EppoClientPollingTest.class);
   private static final String DUMMY_API_KEY = "mock-api-key";
 
-  @Mock private ConfigurationParser<JsonNode> mockConfigParser;
+  @Mock private ConfigurationParser<Configuration, Configuration.Builder, JsonNode> mockConfigParser;
   @Mock private EppoConfigurationClient mockConfigClient;
+
+  private CachingConfigurationStore<Configuration> configurationStore =
+            new FileBackedConfigStore<>(
+                ApplicationProvider.getApplicationContext(),
+                safeCacheKey(DUMMY_API_KEY),
+                new ConfigurationCodec.Default());
 
   @Before
   public void setUp() {
     MockitoAnnotations.openMocks(this);
+  }
+
+  private static class TestBuilder extends AndroidBaseClient.Builder<
+    TestBuilder,
+    Configuration,
+    Configuration.Builder,
+    JsonNode
+  > {
+    protected TestBuilder(
+      @NotNull String apiKey,
+      @NotNull Application application,
+      @NotNull ConfigurationParser<Configuration, Configuration.Builder, JsonNode> configurationParser,
+      @NotNull CachingConfigurationStore<Configuration> configStore,
+      @NotNull EppoConfigurationClient configurationClient) {
+      super(TestBuilder.class, apiKey, application, configurationParser, configStore, configurationClient);
+    }
   }
 
   /**
@@ -41,16 +71,17 @@ public class EppoClientPollingTest {
    * @param pollingIntervalMs Polling interval in milliseconds
    * @return Initialized EppoClient
    */
-  private AndroidBaseClient<JsonNode> buildOfflineClientWithPolling(long pollingIntervalMs)
+  private AndroidBaseClient<Configuration, Configuration.Builder, JsonNode> buildOfflineClientWithPolling(long pollingIntervalMs)
       throws ExecutionException, InterruptedException {
     // Use an empty configuration for offline mode
     CompletableFuture<Configuration> initialConfig =
         CompletableFuture.completedFuture(Configuration.emptyConfig());
 
-    return new AndroidBaseClient.Builder<>(
+    return new TestBuilder(
             DUMMY_API_KEY,
             ApplicationProvider.getApplicationContext(),
             mockConfigParser,
+            configurationStore,
             mockConfigClient)
         .forceReinitialize(true)
         .offlineMode(true)
@@ -67,15 +98,16 @@ public class EppoClientPollingTest {
    *
    * @return Initialized EppoClient
    */
-  private AndroidBaseClient<JsonNode> buildOfflineClientWithoutPolling()
+  private AndroidBaseClient<Configuration, Configuration.Builder, JsonNode> buildOfflineClientWithoutPolling()
       throws ExecutionException, InterruptedException {
     CompletableFuture<Configuration> initialConfig =
         CompletableFuture.completedFuture(Configuration.emptyConfig());
 
-    return new AndroidBaseClient.Builder<>(
+    return new TestBuilder(
             DUMMY_API_KEY,
             ApplicationProvider.getApplicationContext(),
             mockConfigParser,
+            configurationStore,
             mockConfigClient)
         .forceReinitialize(true)
         .offlineMode(true)
@@ -88,7 +120,7 @@ public class EppoClientPollingTest {
 
   @Test
   public void testPauseAndResumePolling() throws ExecutionException, InterruptedException {
-    AndroidBaseClient<JsonNode> androidBaseClient = buildOfflineClientWithPolling(100);
+    AndroidBaseClient<Configuration, Configuration.Builder, JsonNode> androidBaseClient = buildOfflineClientWithPolling(100);
     assertNotNull("Client should be initialized", androidBaseClient);
 
     // Test pause
@@ -111,7 +143,7 @@ public class EppoClientPollingTest {
 
   @Test
   public void testResumePollingWithoutStarting() throws ExecutionException, InterruptedException {
-    AndroidBaseClient<JsonNode> androidBaseClient = buildOfflineClientWithoutPolling();
+    AndroidBaseClient<Configuration, Configuration.Builder, JsonNode> androidBaseClient = buildOfflineClientWithoutPolling();
     assertNotNull("Client should be initialized", androidBaseClient);
 
     // Try to resume polling (should log warning and not crash per EppoClient.java:436-441)
@@ -126,7 +158,7 @@ public class EppoClientPollingTest {
 
   @Test
   public void testMultiplePauseResumeCycles() throws ExecutionException, InterruptedException {
-    AndroidBaseClient<JsonNode> androidBaseClient = buildOfflineClientWithPolling(100);
+    AndroidBaseClient<Configuration, Configuration.Builder, JsonNode> androidBaseClient = buildOfflineClientWithPolling(100);
     assertNotNull("Client should be initialized", androidBaseClient);
 
     // First cycle
@@ -160,7 +192,7 @@ public class EppoClientPollingTest {
   @Test
   public void testPauseResumeSequenceDoesNotCrash()
       throws ExecutionException, InterruptedException {
-    AndroidBaseClient<JsonNode> androidBaseClient = buildOfflineClientWithPolling(50);
+    AndroidBaseClient<Configuration, Configuration.Builder, JsonNode> androidBaseClient = buildOfflineClientWithPolling(50);
 
     // Various sequences that should all work without crashing
     androidBaseClient.pausePolling();
@@ -182,7 +214,7 @@ public class EppoClientPollingTest {
 
   @Test
   public void testPollingNotEnabledAndResume() throws ExecutionException, InterruptedException {
-    AndroidBaseClient<JsonNode> androidBaseClient = buildOfflineClientWithoutPolling();
+    AndroidBaseClient<Configuration, Configuration.Builder, JsonNode> androidBaseClient = buildOfflineClientWithoutPolling();
 
     // Pause should be safe even if not polling
     androidBaseClient.pausePolling();
@@ -200,7 +232,7 @@ public class EppoClientPollingTest {
 
   @Test
   public void testPauseAfterInitDoesNotCrash() throws ExecutionException, InterruptedException {
-    AndroidBaseClient<JsonNode> androidBaseClient = buildOfflineClientWithPolling(100);
+    AndroidBaseClient<Configuration, Configuration.Builder, JsonNode> androidBaseClient = buildOfflineClientWithPolling(100);
 
     // Immediately pause after initialization
     androidBaseClient.pausePolling();

--- a/android-sdk-framework/src/main/java/cloud/eppo/android/framework/AndroidBaseClient.java
+++ b/android-sdk-framework/src/main/java/cloud/eppo/android/framework/AndroidBaseClient.java
@@ -13,6 +13,7 @@ import cloud.eppo.android.framework.storage.ConfigurationCodec;
 import cloud.eppo.android.framework.storage.FileBackedConfigStore;
 import cloud.eppo.api.Configuration;
 import cloud.eppo.api.IAssignmentCache;
+import cloud.eppo.api.SerializableEppoConfiguration;
 import cloud.eppo.http.EppoConfigurationClient;
 import cloud.eppo.logging.AssignmentLogger;
 import cloud.eppo.parser.ConfigurationParser;
@@ -32,7 +33,18 @@ import org.jetbrains.annotations.Nullable;
  *
  * @param <JsonFlagType> The JSON type used for JSON flag values (e.g., JsonNode, JsonElement)
  */
-public class AndroidBaseClient<JsonFlagType> extends BaseEppoClient<JsonFlagType> {
+public class AndroidBaseClient<
+  ConfigurationType extends SerializableEppoConfiguration,
+  ConfigurationBuilderType extends SerializableEppoConfiguration.AbstractBuilder<
+    ConfigurationBuilderType,
+    ConfigurationType
+  >,
+  JsonFlagType
+> extends BaseEppoClient<
+  ConfigurationType,
+  ConfigurationBuilderType,
+  JsonFlagType
+> {
   private static final String TAG = logTag(AndroidBaseClient.class);
   private static final boolean DEFAULT_IS_GRACEFUL_MODE = true;
   private static final boolean DEFAULT_OBFUSCATE_CONFIG = true;
@@ -42,7 +54,7 @@ public class AndroidBaseClient<JsonFlagType> extends BaseEppoClient<JsonFlagType
   private long pollingIntervalMs;
   private long pollingJitterMs;
 
-  @Nullable private static AndroidBaseClient<?> instance;
+  @Nullable private static AndroidBaseClient<?, ?, ?> instance;
 
   /**
    * Private constructor. Use Builder to construct instances.
@@ -66,12 +78,12 @@ public class AndroidBaseClient<JsonFlagType> extends BaseEppoClient<JsonFlagType
       String sdkVersion,
       @Nullable String apiBaseUrl,
       @Nullable AssignmentLogger assignmentLogger,
-      CachingConfigurationStore configurationStore,
+      CachingConfigurationStore<ConfigurationType> configurationStore,
       boolean isGracefulMode,
       boolean expectObfuscatedConfig,
-      @Nullable CompletableFuture<Configuration> initialConfiguration,
+      @Nullable CompletableFuture<ConfigurationType> initialConfiguration,
       @Nullable IAssignmentCache assignmentCache,
-      ConfigurationParser<JsonFlagType> configurationParser,
+      ConfigurationParser<ConfigurationType, ConfigurationBuilderType, JsonFlagType> configurationParser,
       EppoConfigurationClient configurationClient) {
     super(
         apiKey,
@@ -96,14 +108,23 @@ public class AndroidBaseClient<JsonFlagType> extends BaseEppoClient<JsonFlagType
    *
    * @return The singleton instance
    * @throws NotInitializedException if the client has not been initialized
-   * @param <T> The JSON type parameter
+   * @param <ConfigurationType> The Configuration type parameter
+   * @param <ConfigurationBuilderType> The Configuration Builder type parameter
+   * @param <JsonFlagType> The JSON type parameter
    */
   @SuppressWarnings("unchecked")
-  public static <T> AndroidBaseClient<T> getInstance() throws NotInitializedException {
+  public static <
+        ConfigurationType extends SerializableEppoConfiguration,
+        ConfigurationBuilderType extends SerializableEppoConfiguration.AbstractBuilder<
+          ConfigurationBuilderType,
+          ConfigurationType
+        >,
+        JsonFlagType
+      > AndroidBaseClient<ConfigurationType, ConfigurationBuilderType, JsonFlagType> getInstance() throws NotInitializedException {
     if (instance == null) {
       throw new NotInitializedException();
     }
-    return (AndroidBaseClient<T>) instance;
+    return (AndroidBaseClient<ConfigurationType, ConfigurationBuilderType, JsonFlagType>) instance;
   }
 
   /**
@@ -114,118 +135,152 @@ public class AndroidBaseClient<JsonFlagType> extends BaseEppoClient<JsonFlagType
    *
    * @param <JsonFlagType> The JSON type used for JSON flag values
    */
-  public static class Builder<JsonFlagType> {
+  public abstract static class Builder<
+      SelfType extends Builder<
+        SelfType,
+        ConfigurationType,
+        ConfigurationBuilderType,
+        JsonFlagType
+      >,
+      ConfigurationType extends SerializableEppoConfiguration,
+      ConfigurationBuilderType extends SerializableEppoConfiguration.AbstractBuilder<
+        ConfigurationBuilderType,
+        ConfigurationType
+      >,
+      JsonFlagType
+    > {
     // Required parameters
-    private final String apiKey;
-    private final Application application;
-    private final ConfigurationParser<JsonFlagType> configurationParser;
-    private final EppoConfigurationClient configurationClient;
+    protected final Class<SelfType> selfClass;
+    protected final String apiKey;
+    protected final Application application;
+    protected final ConfigurationParser<ConfigurationType, ConfigurationBuilderType, JsonFlagType> configurationParser;
+    protected final CachingConfigurationStore<ConfigurationType> configStore;
+    protected final EppoConfigurationClient configurationClient;
 
     // Optional parameters with defaults
-    @Nullable private String apiBaseUrl;
-    @Nullable private AssignmentLogger assignmentLogger;
-    @Nullable private CachingConfigurationStore configStore;
-    private boolean isGracefulMode = DEFAULT_IS_GRACEFUL_MODE;
-    private boolean obfuscateConfig = DEFAULT_OBFUSCATE_CONFIG;
-    private boolean forceReinitialize = false;
-    private boolean offlineMode = false;
-    @Nullable private CompletableFuture<Configuration> initialConfiguration;
-    private boolean ignoreCachedConfiguration = false;
-    private boolean pollingEnabled = false;
-    private long pollingIntervalMs = DEFAULT_POLLING_INTERVAL_MS;
-    private long pollingJitterMs = -1;
-    @Nullable private IAssignmentCache assignmentCache;
-    @Nullable private Consumer<Configuration> configChangeCallback;
+    @Nullable protected String apiBaseUrl;
+    @Nullable protected AssignmentLogger assignmentLogger;
+    protected boolean isGracefulMode = DEFAULT_IS_GRACEFUL_MODE;
+    protected boolean obfuscateConfig = DEFAULT_OBFUSCATE_CONFIG;
+    protected boolean forceReinitialize = false;
+    protected boolean offlineMode = false;
+    @Nullable protected CompletableFuture<ConfigurationType> initialConfiguration;
+    protected boolean ignoreCachedConfiguration = false;
+    protected boolean pollingEnabled = false;
+    protected long pollingIntervalMs = DEFAULT_POLLING_INTERVAL_MS;
+    protected long pollingJitterMs = -1;
+    @Nullable protected IAssignmentCache assignmentCache;
+    @Nullable protected Consumer<ConfigurationType> configChangeCallback;
 
     /**
      * Creates a new Builder with required parameters.
      *
+     * @param selfClass The class of the instance you're instantiating so that builder methods
+     *                  can return the right type. This is only for sublcasses.
      * @param apiKey API key for Eppo (required)
      * @param application Application context (required)
      * @param configurationParser Parser for configuration JSON (required)
+     * @param configStore Store for configurations (required)
      * @param configurationClient HTTP client for configuration fetching (required)
      */
-    public Builder(
+    protected Builder(
+        @NotNull Class<SelfType> selfClass,
         @NotNull String apiKey,
         @NotNull Application application,
-        @NotNull ConfigurationParser<JsonFlagType> configurationParser,
+        @NotNull ConfigurationParser<ConfigurationType, ConfigurationBuilderType, JsonFlagType> configurationParser,
+        @NotNull CachingConfigurationStore<ConfigurationType> configStore,
         @NotNull EppoConfigurationClient configurationClient) {
+      if (selfClass == null) {
+        throw new IllegalArgumentException("Missing self class. Bad subclass");
+      }
+      if (apiKey == null) {
+        throw new IllegalArgumentException("Missing API Key");
+      }
+      if (application == null) {
+        throw new IllegalArgumentException("Missing Application");
+      }
+      if (configurationParser == null) {
+        throw new IllegalArgumentException("Missing ConfigurationParser");
+      }
+      if (configStore == null) {
+        throw new IllegalArgumentException("Missing CachingConfigurationStore");
+      }
+      if (configurationClient == null) {
+        throw new IllegalArgumentException("Missing EppoConfigurationClient");
+      }
+      this.selfClass = selfClass;
       this.apiKey = apiKey;
       this.application = application;
       this.configurationParser = configurationParser;
+      this.configStore = configStore;
       this.configurationClient = configurationClient;
     }
 
-    public Builder<JsonFlagType> apiBaseUrl(@Nullable String apiBaseUrl) {
+    public SelfType apiBaseUrl(@Nullable String apiBaseUrl) {
       this.apiBaseUrl = apiBaseUrl;
-      return this;
+      return selfClass.cast(this);
     }
 
-    public Builder<JsonFlagType> assignmentLogger(@Nullable AssignmentLogger assignmentLogger) {
+    public SelfType assignmentLogger(@Nullable AssignmentLogger assignmentLogger) {
       this.assignmentLogger = assignmentLogger;
-      return this;
+      return selfClass.cast(this);
     }
 
-    public Builder<JsonFlagType> configStore(@Nullable CachingConfigurationStore configStore) {
-      this.configStore = configStore;
-      return this;
-    }
-
-    public Builder<JsonFlagType> isGracefulMode(boolean isGracefulMode) {
+    public SelfType isGracefulMode(boolean isGracefulMode) {
       this.isGracefulMode = isGracefulMode;
-      return this;
+      return selfClass.cast(this);
     }
 
-    public Builder<JsonFlagType> obfuscateConfig(boolean obfuscateConfig) {
+    public SelfType obfuscateConfig(boolean obfuscateConfig) {
       this.obfuscateConfig = obfuscateConfig;
-      return this;
+      return selfClass.cast(this);
     }
 
-    public Builder<JsonFlagType> forceReinitialize(boolean forceReinitialize) {
+    public SelfType forceReinitialize(boolean forceReinitialize) {
       this.forceReinitialize = forceReinitialize;
-      return this;
+      return selfClass.cast(this);
     }
 
-    public Builder<JsonFlagType> offlineMode(boolean offlineMode) {
+    public SelfType offlineMode(boolean offlineMode) {
       this.offlineMode = offlineMode;
-      return this;
+      return selfClass.cast(this);
     }
 
-    public Builder<JsonFlagType> initialConfiguration(
-        @Nullable CompletableFuture<Configuration> initialConfiguration) {
+    public SelfType initialConfiguration(
+        @Nullable CompletableFuture<ConfigurationType> initialConfiguration) {
       this.initialConfiguration = initialConfiguration;
-      return this;
+      return selfClass.cast(this);
     }
 
-    public Builder<JsonFlagType> ignoreCachedConfiguration(boolean ignoreCache) {
+    public SelfType ignoreCachedConfiguration(boolean ignoreCache) {
       this.ignoreCachedConfiguration = ignoreCache;
-      return this;
+      return selfClass.cast(this);
     }
 
-    public Builder<JsonFlagType> pollingEnabled(boolean pollingEnabled) {
+    public SelfType pollingEnabled(boolean pollingEnabled) {
       this.pollingEnabled = pollingEnabled;
-      return this;
+      return selfClass.cast(this);
     }
 
-    public Builder<JsonFlagType> pollingIntervalMs(long pollingIntervalMs) {
+    public SelfType pollingIntervalMs(long pollingIntervalMs) {
       this.pollingIntervalMs = pollingIntervalMs;
-      return this;
+      return selfClass.cast(this);
     }
 
-    public Builder<JsonFlagType> pollingJitterMs(long pollingJitterMs) {
+    public SelfType pollingJitterMs(long pollingJitterMs) {
       this.pollingJitterMs = pollingJitterMs;
-      return this;
+      return selfClass.cast(this);
     }
 
-    public Builder<JsonFlagType> assignmentCache(@Nullable IAssignmentCache assignmentCache) {
+    public SelfType assignmentCache(@Nullable IAssignmentCache assignmentCache) {
       this.assignmentCache = assignmentCache;
-      return this;
+      return selfClass.cast(this);
     }
 
-    public Builder<JsonFlagType> onConfigurationChange(
-        @Nullable Consumer<Configuration> configChangeCallback) {
+    public SelfType onConfigurationChange(
+        @Nullable Consumer<ConfigurationType> configChangeCallback) {
       this.configChangeCallback = configChangeCallback;
-      return this;
+      return selfClass.cast(this);
     }
 
     /**
@@ -245,12 +300,18 @@ public class AndroidBaseClient<JsonFlagType> extends BaseEppoClient<JsonFlagType
      *
      * @return CompletableFuture that completes with the initialized EppoClient
      */
-    public CompletableFuture<AndroidBaseClient<JsonFlagType>> buildAndInitAsync() {
+    public CompletableFuture<
+          AndroidBaseClient<
+            ConfigurationType,
+            ConfigurationBuilderType,
+            JsonFlagType
+          >
+        > buildAndInitAsync() {
       // Singleton handling
       if (instance != null && !forceReinitialize) {
         Log.w(TAG, "Eppo Client instance already initialized");
         @SuppressWarnings("unchecked")
-        AndroidBaseClient<JsonFlagType> typedInstance = (AndroidBaseClient<JsonFlagType>) instance;
+        AndroidBaseClient<ConfigurationType, ConfigurationBuilderType, JsonFlagType> typedInstance = (AndroidBaseClient<ConfigurationType, ConfigurationBuilderType, JsonFlagType>) instance;
         return CompletableFuture.completedFuture(typedInstance);
       } else if (instance != null) {
         // Stop polling if reinitializing
@@ -261,21 +322,13 @@ public class AndroidBaseClient<JsonFlagType> extends BaseEppoClient<JsonFlagType
       String sdkName = obfuscateConfig ? "android" : "android-debug";
       String sdkVersion = BuildConfig.EPPO_VERSION;
 
-      if (configStore == null) {
-        configStore =
-            new FileBackedConfigStore(
-                application,
-                safeCacheKey(apiKey),
-                new ConfigurationCodec.Default<>(Configuration.class));
-      }
-
       // Use the persisted cache as the initial configuration if none was explicitly provided.
       if (initialConfiguration == null && !ignoreCachedConfiguration) {
         initialConfiguration = configStore.loadFromStorage();
       }
 
       // Construct the client
-      AndroidBaseClient<JsonFlagType> newInstance =
+      AndroidBaseClient<ConfigurationType, ConfigurationBuilderType, JsonFlagType> newInstance =
           new AndroidBaseClient<>(
               apiKey,
               sdkName,
@@ -298,7 +351,7 @@ public class AndroidBaseClient<JsonFlagType> extends BaseEppoClient<JsonFlagType
         newInstance.onConfigurationChange(configChangeCallback);
       }
 
-      final CompletableFuture<AndroidBaseClient<JsonFlagType>> ret = new CompletableFuture<>();
+      final CompletableFuture<AndroidBaseClient<ConfigurationType, ConfigurationBuilderType, JsonFlagType>> ret = new CompletableFuture<>();
       AtomicInteger failCount = new AtomicInteger(0);
 
       if (!offlineMode) {
@@ -366,7 +419,11 @@ public class AndroidBaseClient<JsonFlagType> extends BaseEppoClient<JsonFlagType
      *
      * @return The initialized EppoClient
      */
-    public AndroidBaseClient<JsonFlagType> buildAndInit() {
+    public AndroidBaseClient<
+          ConfigurationType,
+          ConfigurationBuilderType,
+          JsonFlagType
+        > buildAndInit() {
       try {
         return buildAndInitAsync().get();
       } catch (ExecutionException | InterruptedException | CompletionException e) {
@@ -378,8 +435,8 @@ public class AndroidBaseClient<JsonFlagType> extends BaseEppoClient<JsonFlagType
           if (cause instanceof RuntimeException
               && cause.getCause() instanceof EppoInitializationException) {
             @SuppressWarnings("unchecked")
-            AndroidBaseClient<JsonFlagType> typedInstance =
-                (AndroidBaseClient<JsonFlagType>) instance;
+            AndroidBaseClient<ConfigurationType, ConfigurationBuilderType, JsonFlagType> typedInstance =
+                (AndroidBaseClient<ConfigurationType, ConfigurationBuilderType, JsonFlagType>) instance;
             return typedInstance;
           }
         }
@@ -389,7 +446,7 @@ public class AndroidBaseClient<JsonFlagType> extends BaseEppoClient<JsonFlagType
         }
       }
       @SuppressWarnings("unchecked")
-      AndroidBaseClient<JsonFlagType> typedInstance = (AndroidBaseClient<JsonFlagType>) instance;
+      AndroidBaseClient<ConfigurationType, ConfigurationBuilderType, JsonFlagType> typedInstance = (AndroidBaseClient<ConfigurationType, ConfigurationBuilderType, JsonFlagType>) instance;
       return typedInstance;
     }
   }

--- a/android-sdk-framework/src/main/java/cloud/eppo/android/framework/AndroidBaseClient.java
+++ b/android-sdk-framework/src/main/java/cloud/eppo/android/framework/AndroidBaseClient.java
@@ -138,6 +138,12 @@ public class AndroidBaseClient<
   public abstract static class Builder<
       SelfType extends Builder<
         SelfType,
+        AndroidBaseClientType,
+        ConfigurationType,
+        ConfigurationBuilderType,
+        JsonFlagType
+      >,
+      AndroidBaseClientType extends AndroidBaseClient<
         ConfigurationType,
         ConfigurationBuilderType,
         JsonFlagType
@@ -284,6 +290,24 @@ public class AndroidBaseClient<
     }
 
     /**
+     * For subclasses to initialize the proper type
+     * @see AndroidBaseClient constructor
+     */
+    protected abstract AndroidBaseClientType newInstance(
+      String apiKey,
+      String sdkName,
+      String sdkVersion,
+      @Nullable String apiBaseUrl,
+      @Nullable AssignmentLogger assignmentLogger,
+      CachingConfigurationStore<ConfigurationType> configurationStore,
+      boolean isGracefulMode,
+      boolean expectObfuscatedConfig,
+      @Nullable CompletableFuture<ConfigurationType> initialConfiguration,
+      @Nullable IAssignmentCache assignmentCache,
+      ConfigurationParser<ConfigurationType, ConfigurationBuilderType, JsonFlagType> configurationParser,
+      EppoConfigurationClient configurationClient);
+
+    /**
      * Builds and initializes the EppoClient asynchronously.
      *
      * <p>This method performs the full initialization flow:
@@ -300,18 +324,12 @@ public class AndroidBaseClient<
      *
      * @return CompletableFuture that completes with the initialized EppoClient
      */
-    public CompletableFuture<
-          AndroidBaseClient<
-            ConfigurationType,
-            ConfigurationBuilderType,
-            JsonFlagType
-          >
-        > buildAndInitAsync() {
+    public CompletableFuture<AndroidBaseClientType> buildAndInitAsync() {
       // Singleton handling
       if (instance != null && !forceReinitialize) {
         Log.w(TAG, "Eppo Client instance already initialized");
         @SuppressWarnings("unchecked")
-        AndroidBaseClient<ConfigurationType, ConfigurationBuilderType, JsonFlagType> typedInstance = (AndroidBaseClient<ConfigurationType, ConfigurationBuilderType, JsonFlagType>) instance;
+        AndroidBaseClientType typedInstance = (AndroidBaseClientType) instance;
         return CompletableFuture.completedFuture(typedInstance);
       } else if (instance != null) {
         // Stop polling if reinitializing
@@ -328,8 +346,8 @@ public class AndroidBaseClient<
       }
 
       // Construct the client
-      AndroidBaseClient<ConfigurationType, ConfigurationBuilderType, JsonFlagType> newInstance =
-          new AndroidBaseClient<>(
+      AndroidBaseClientType newInstance =
+          newInstance(
               apiKey,
               sdkName,
               sdkVersion,
@@ -351,7 +369,7 @@ public class AndroidBaseClient<
         newInstance.onConfigurationChange(configChangeCallback);
       }
 
-      final CompletableFuture<AndroidBaseClient<ConfigurationType, ConfigurationBuilderType, JsonFlagType>> ret = new CompletableFuture<>();
+      final CompletableFuture<AndroidBaseClientType> ret = new CompletableFuture<>();
       AtomicInteger failCount = new AtomicInteger(0);
 
       if (!offlineMode) {

--- a/android-sdk-framework/src/main/java/cloud/eppo/android/framework/storage/CachingConfigurationStore.java
+++ b/android-sdk-framework/src/main/java/cloud/eppo/android/framework/storage/CachingConfigurationStore.java
@@ -1,7 +1,8 @@
 package cloud.eppo.android.framework.storage;
 
 import cloud.eppo.IConfigurationStore;
-import cloud.eppo.api.Configuration;
+import cloud.eppo.api.SerializableEppoConfiguration;
+
 import java.util.concurrent.CompletableFuture;
 import org.jetbrains.annotations.NotNull;
 
@@ -9,21 +10,24 @@ import org.jetbrains.annotations.NotNull;
  * Abstract config store that keeps an in-memory configuration and can persist it via a {@link
  * ByteStore} and {@link ConfigurationCodec}.
  */
-public class CachingConfigurationStore implements IConfigurationStore {
+public class CachingConfigurationStore<
+  ConfigurationType extends SerializableEppoConfiguration
+> implements IConfigurationStore<ConfigurationType> {
 
-  private final ConfigurationCodec<Configuration> codec;
+  private final ConfigurationCodec<ConfigurationType> codec;
   private final ByteStore byteStore;
-  private volatile Configuration configuration = Configuration.emptyConfig();
+  private volatile ConfigurationType configuration;
 
   protected CachingConfigurationStore(
-      @NotNull ConfigurationCodec<Configuration> codec, @NotNull ByteStore byteStore) {
+      @NotNull ConfigurationCodec<ConfigurationType> codec, @NotNull ByteStore byteStore) {
+    this.configuration = codec.emptyConfiguration();
     this.codec = codec;
     this.byteStore = byteStore;
   }
 
   /** Returns the current in-memory configuration. */
   @Override
-  @NotNull public Configuration getConfiguration() {
+  @NotNull public ConfigurationType getConfiguration() {
     return configuration;
   }
 
@@ -35,7 +39,7 @@ public class CachingConfigurationStore implements IConfigurationStore {
    * @throws IllegalArgumentException if config is null
    */
   @Override
-  @NotNull public CompletableFuture<Void> saveConfiguration(@NotNull Configuration config) {
+  @NotNull public CompletableFuture<Void> saveConfiguration(@NotNull ConfigurationType config) {
     if (config == null) {
       throw new IllegalArgumentException("config must not be null");
     }
@@ -54,7 +58,7 @@ public class CachingConfigurationStore implements IConfigurationStore {
    * @return a future that completes with the loaded configuration, or null if storage is empty or
    *     missing
    */
-  @NotNull public CompletableFuture<Configuration> loadFromStorage() {
+  @NotNull public CompletableFuture<ConfigurationType> loadFromStorage() {
     return byteStore
         .read()
         .thenApply(

--- a/android-sdk-framework/src/main/java/cloud/eppo/android/framework/storage/ConfigurationCodec.java
+++ b/android-sdk-framework/src/main/java/cloud/eppo/android/framework/storage/ConfigurationCodec.java
@@ -1,5 +1,6 @@
 package cloud.eppo.android.framework.storage;
 
+import cloud.eppo.api.Configuration;
 import cloud.eppo.api.SerializableEppoConfiguration;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -13,9 +14,9 @@ import org.jetbrains.annotations.NotNull;
  *
  * <p>Used for persisting configurations to storage.
  *
- * @param <T> the configuration type, must extend SerializableEppoConfiguration
+ * @param <ConfigurationType> the configuration type, must extend SerializableEppoConfiguration
  */
-public interface ConfigurationCodec<T extends SerializableEppoConfiguration> {
+public interface ConfigurationCodec<ConfigurationType extends SerializableEppoConfiguration> {
   /**
    * Serializes a configuration to bytes for storage.
    *
@@ -23,7 +24,7 @@ public interface ConfigurationCodec<T extends SerializableEppoConfiguration> {
    * @return serialized bytes (must not be null)
    * @throws RuntimeException if the configuration cannot be serialized
    */
-  byte[] toBytes(@NotNull T configuration);
+  byte[] toBytes(@NotNull ConfigurationType configuration);
 
   /**
    * Deserializes a configuration from bytes produced by {@link #toBytes}.
@@ -32,7 +33,7 @@ public interface ConfigurationCodec<T extends SerializableEppoConfiguration> {
    * @return the deserialized configuration
    * @throws RuntimeException if the bytes cannot be deserialized to a configuration
    */
-  @NotNull T fromBytes(byte[] bytes);
+  @NotNull ConfigurationType fromBytes(byte[] bytes);
 
   /**
    * Returns the MIME content type of the serialized form (e.g. {@code
@@ -42,29 +43,23 @@ public interface ConfigurationCodec<T extends SerializableEppoConfiguration> {
   @NotNull String getContentType();
 
   /**
+   * Generic equivalent to {@link Configuration#emptyConfig()}
+   * @return an empty Configuration.
+   */
+  @NotNull ConfigurationType emptyConfiguration();
+
+  /**
    * Default implementation using Java serialization.
    *
    * <p><strong>Security Note:</strong> Java serialization is used for local storage. Do not use
    * this codec to deserialize data from untrusted sources, as Java deserialization has known
    * security vulnerabilities.
    *
-   * @param <T> the configuration type, must extend SerializableEppoConfiguration
+   * @param <ConfigurationType> the configuration type, must extend SerializableEppoConfiguration
    */
-  public static class Default<T extends SerializableEppoConfiguration>
-      implements ConfigurationCodec<T> {
-    private final Class<T> configClass;
-
-    /**
-     * Creates a default codec for the specified configuration class.
-     *
-     * @param configClass the class of the configuration type
-     */
-    public Default(@NotNull Class<T> configClass) {
-      this.configClass = configClass;
-    }
-
+  public static class Default implements ConfigurationCodec<Configuration> {
     @Override
-    public byte[] toBytes(@NotNull T configuration) {
+    public byte[] toBytes(@NotNull Configuration configuration) {
       if (configuration == null) {
         throw new IllegalArgumentException("Configuration must not be null");
       }
@@ -79,20 +74,18 @@ public interface ConfigurationCodec<T extends SerializableEppoConfiguration> {
 
     @Override
     @SuppressWarnings("unchecked") // Safe cast - verified by configClass.isInstance() check
-    public @NotNull T fromBytes(byte[] bytes) {
+    public @NotNull Configuration fromBytes(byte[] bytes) {
       if (bytes == null) {
         throw new IllegalArgumentException("Bytes must not be null");
       }
       try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
         Object obj = ois.readObject();
-        if (!configClass.isInstance(obj)) {
+        if (!(obj instanceof Configuration)) {
           throw new RuntimeException(
-              "Deserialized object is not a "
-                  + configClass.getSimpleName()
-                  + ": "
+              "Deserialized object is not a Configuration:"
                   + obj.getClass().getName());
         }
-        return (T) obj;
+        return (Configuration) obj;
       } catch (IOException e) {
         throw new RuntimeException("Failed to deserialize configuration", e);
       } catch (ClassNotFoundException e) {
@@ -103,6 +96,11 @@ public interface ConfigurationCodec<T extends SerializableEppoConfiguration> {
     @Override
     public @NotNull String getContentType() {
       return "application/x-java-serialized-object";
+    }
+
+    @Override
+    public @NotNull Configuration emptyConfiguration() {
+      return Configuration.emptyConfig();
     }
   }
 }

--- a/android-sdk-framework/src/main/java/cloud/eppo/android/framework/storage/FileBackedConfigStore.java
+++ b/android-sdk-framework/src/main/java/cloud/eppo/android/framework/storage/FileBackedConfigStore.java
@@ -2,9 +2,13 @@ package cloud.eppo.android.framework.storage;
 
 import android.app.Application;
 import cloud.eppo.api.Configuration;
+import cloud.eppo.api.SerializableEppoConfiguration;
+
 import org.jetbrains.annotations.NotNull;
 
-public class FileBackedConfigStore extends CachingConfigurationStore {
+public class FileBackedConfigStore<
+  ConfigurationType extends SerializableEppoConfiguration
+> extends CachingConfigurationStore<ConfigurationType> {
 
   /**
    * Creates a FileBackedStore with the specified configuration.
@@ -16,12 +20,14 @@ public class FileBackedConfigStore extends CachingConfigurationStore {
   public FileBackedConfigStore(
       @NotNull Application application,
       @NotNull String cacheFileSuffix,
-      @NotNull ConfigurationCodec<Configuration> codec) {
+      @NotNull ConfigurationCodec<ConfigurationType> codec) {
     super(codec, createByteStore(application, cacheFileSuffix, codec));
   }
 
-  private static ByteStore createByteStore(
-      Application application, String cacheFileSuffix, ConfigurationCodec<Configuration> codec) {
+  private static <
+        ConfigurationType extends SerializableEppoConfiguration
+      > ByteStore createByteStore(
+      Application application, String cacheFileSuffix, ConfigurationCodec<ConfigurationType> codec) {
     ConfigCacheFile cacheFile =
         new ConfigCacheFile(application, cacheFileSuffix, codec.getContentType());
     return new FileBackedByteStore(cacheFile);

--- a/android-sdk-framework/src/test/java/cloud/eppo/android/framework/storage/CachingConfigurationStoreTest.java
+++ b/android-sdk-framework/src/test/java/cloud/eppo/android/framework/storage/CachingConfigurationStoreTest.java
@@ -35,7 +35,7 @@ public class CachingConfigurationStoreTest {
 
   private ByteStore mockByteStore;
   private ConfigurationCodec<Configuration> spyCodec;
-  private CachingConfigurationStore testedStore;
+  private CachingConfigurationStore<Configuration> testedStore;
 
   /** One shared non-empty configuration used across tests (built once in setUp). */
   private Configuration sampleConfiguration;
@@ -46,12 +46,12 @@ public class CachingConfigurationStoreTest {
   @Before
   public void setUp() throws Exception {
     mockByteStore = mock(ByteStore.class);
-    spyCodec = spy(new ConfigurationCodec.Default<>(Configuration.class));
-    testedStore = new CachingConfigurationStore(spyCodec, mockByteStore);
+    spyCodec = spy(new ConfigurationCodec.Default());
+    testedStore = new CachingConfigurationStore<>(spyCodec, mockByteStore);
     // Parse flags-v1.json from test resources using sdk-common-jvm JacksonConfigurationParser.
     sampleConfiguration = loadSampleConfigurationFromResource();
     ConfigurationCodec<Configuration> realCodec =
-        new ConfigurationCodec.Default<>(Configuration.class);
+        new ConfigurationCodec.Default();
     sampleConfigurationBytes = realCodec.toBytes(sampleConfiguration);
   }
 

--- a/android-sdk-framework/src/test/java/cloud/eppo/android/framework/storage/ConfigurationCodecTest.java
+++ b/android-sdk-framework/src/test/java/cloud/eppo/android/framework/storage/ConfigurationCodecTest.java
@@ -19,11 +19,11 @@ import org.robolectric.RobolectricTestRunner;
 @RunWith(RobolectricTestRunner.class)
 public class ConfigurationCodecTest {
 
-  private ConfigurationCodec<SerializableEppoConfiguration> codec;
+  private ConfigurationCodec<Configuration> codec;
 
   @Before
   public void setUp() {
-    codec = new ConfigurationCodec.Default<>(SerializableEppoConfiguration.class);
+    codec = new ConfigurationCodec.Default();
   }
 
   @Test
@@ -92,14 +92,13 @@ public class ConfigurationCodecTest {
     } catch (RuntimeException e) {
       assertTrue(
           "Exception should mention type mismatch",
-          e.getMessage().contains("not a SerializableEppoConfiguration"));
+          e.getMessage().contains("not a Configuration"));
     }
   }
 
   @Test
   public void roundTrip_serializeAndDeserialize_succeeds() {
-    SerializableEppoConfiguration original =
-        (SerializableEppoConfiguration) Configuration.emptyConfig();
+    Configuration original = Configuration.emptyConfig();
     byte[] bytes = codec.toBytes(original);
     assertNotNull(bytes);
     assertTrue(bytes.length > 0);

--- a/android-sdk-framework/src/test/java/cloud/eppo/android/framework/storage/FileBackedConfigStoreTest.java
+++ b/android-sdk-framework/src/test/java/cloud/eppo/android/framework/storage/FileBackedConfigStoreTest.java
@@ -24,20 +24,20 @@ public class FileBackedConfigStoreTest {
   @Before
   public void setUp() {
     application = RuntimeEnvironment.getApplication();
-    codec = new ConfigurationCodec.Default<>(Configuration.class);
+    codec = new ConfigurationCodec.Default();
     cacheFileSuffix = "test-" + System.currentTimeMillis();
   }
 
   @Test
   public void construct_withValidArgs_succeeds() {
-    FileBackedConfigStore store = new FileBackedConfigStore(application, cacheFileSuffix, codec);
+    FileBackedConfigStore<Configuration> store = new FileBackedConfigStore<>(application, cacheFileSuffix, codec);
 
     assertNotNull(store);
   }
 
   @Test
   public void getConfiguration_beforeAnySave_returnsEmptyConfig() {
-    FileBackedConfigStore store = new FileBackedConfigStore(application, cacheFileSuffix, codec);
+    FileBackedConfigStore<Configuration> store = new FileBackedConfigStore<>(application, cacheFileSuffix, codec);
 
     Configuration config = store.getConfiguration();
 
@@ -47,7 +47,7 @@ public class FileBackedConfigStoreTest {
 
   @Test
   public void saveConfiguration_thenGetConfiguration_returnsSavedConfig() throws Exception {
-    FileBackedConfigStore store = new FileBackedConfigStore(application, cacheFileSuffix, codec);
+    FileBackedConfigStore<Configuration> store = new FileBackedConfigStore<>(application, cacheFileSuffix, codec);
     Configuration toSave = Configuration.emptyConfig();
 
     store.saveConfiguration(toSave).get(5, TimeUnit.SECONDS);
@@ -57,7 +57,7 @@ public class FileBackedConfigStoreTest {
 
   @Test
   public void loadFromStorage_whenNothingSaved_returnsNull() throws Exception {
-    FileBackedConfigStore store = new FileBackedConfigStore(application, cacheFileSuffix, codec);
+    FileBackedConfigStore<Configuration> store = new FileBackedConfigStore<>(application, cacheFileSuffix, codec);
 
     Configuration loaded = store.loadFromStorage().get(5, TimeUnit.SECONDS);
 
@@ -66,7 +66,7 @@ public class FileBackedConfigStoreTest {
 
   @Test
   public void saveConfiguration_thenLoadFromStorage_returnsSameConfig() throws Exception {
-    FileBackedConfigStore store = new FileBackedConfigStore(application, cacheFileSuffix, codec);
+    FileBackedConfigStore<Configuration> store = new FileBackedConfigStore<>(application, cacheFileSuffix, codec);
     Configuration toSave = Configuration.emptyConfig();
 
     store.saveConfiguration(toSave).get(5, TimeUnit.SECONDS);

--- a/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
+++ b/eppo/src/androidTest/java/cloud/eppo/android/EppoClientTest.java
@@ -858,8 +858,9 @@ public class EppoClientTest {
           }
         };
 
-    ConfigurationCodec<Configuration> codec = new ConfigurationCodec.Default<>(Configuration.class);
-    CachingConfigurationStore slowStore = new CachingConfigurationStore(codec, slowByteStore) {};
+    ConfigurationCodec<Configuration> codec = new ConfigurationCodec.Default();
+    CachingConfigurationStore<Configuration> slowStore =
+        new CachingConfigurationStore<Configuration>(codec, slowByteStore) {};
 
     initClient(
         TEST_HOST, true, false, false, true, null, slowStore, DUMMY_API_KEY, false, null, false);
@@ -1081,7 +1082,7 @@ public class EppoClientTest {
    * @return serialized bytes
    */
   private byte[] serializeConfiguration(Configuration config) {
-    ConfigurationCodec<Configuration> codec = new ConfigurationCodec.Default<>(Configuration.class);
+    ConfigurationCodec<Configuration> codec = new ConfigurationCodec.Default();
     return codec.toBytes(config);
   }
 }

--- a/eppo/src/main/java/cloud/eppo/android/EppoClient.java
+++ b/eppo/src/main/java/cloud/eppo/android/EppoClient.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
-public class EppoClient extends AndroidBaseClient<JsonNode> {
+public class EppoClient extends AndroidBaseClient<Configuration, Configuration.Builder, JsonNode> {
   private static final String TAG = logTag(EppoClient.class);
   private static final boolean DEFAULT_IS_GRACEFUL_MODE = true;
   private static final boolean DEFAULT_OBFUSCATE_CONFIG = true;
@@ -44,8 +44,8 @@ public class EppoClient extends AndroidBaseClient<JsonNode> {
       String sdkVersion,
       @Nullable String apiBaseUrl,
       @Nullable AssignmentLogger assignmentLogger,
-      CachingConfigurationStore configurationStore,
-      ConfigurationParser<JsonNode> configurationParser,
+      CachingConfigurationStore<Configuration> configurationStore,
+      ConfigurationParser<Configuration, Configuration.Builder, JsonNode> configurationParser,
       EppoConfigurationClient configurationClient,
       boolean isGracefulMode,
       boolean expectObfuscatedConfig,
@@ -129,7 +129,7 @@ public class EppoClient extends AndroidBaseClient<JsonNode> {
     private final String apiKey;
     @Nullable private AssignmentLogger assignmentLogger;
 
-    @Nullable private CachingConfigurationStore configStore;
+    @Nullable private CachingConfigurationStore<Configuration> configStore;
 
     private boolean isGracefulMode = DEFAULT_IS_GRACEFUL_MODE;
     private boolean obfuscateConfig = DEFAULT_OBFUSCATE_CONFIG;
@@ -151,7 +151,7 @@ public class EppoClient extends AndroidBaseClient<JsonNode> {
     @Nullable private Consumer<Configuration> configChangeCallback;
 
     // Batteries-included: Allow overriding default implementations
-    @Nullable private ConfigurationParser<JsonNode> configurationParser;
+    @Nullable private ConfigurationParser<Configuration, Configuration.Builder, JsonNode> configurationParser;
     @Nullable private EppoConfigurationClient configurationClient;
 
     public Builder(@NonNull String apiKey, @NonNull Application application) {
@@ -204,7 +204,7 @@ public class EppoClient extends AndroidBaseClient<JsonNode> {
       return this;
     }
 
-    public Builder configStore(CachingConfigurationStore configStore) {
+    public Builder configStore(CachingConfigurationStore<Configuration> configStore) {
       this.configStore = configStore;
       return this;
     }
@@ -252,7 +252,7 @@ public class EppoClient extends AndroidBaseClient<JsonNode> {
      * @param parser the configuration parser to use
      * @return this builder
      */
-    public Builder configurationParser(ConfigurationParser<JsonNode> parser) {
+    public Builder configurationParser(ConfigurationParser<Configuration, Configuration.Builder, JsonNode> parser) {
       this.configurationParser = parser;
       return this;
     }
@@ -303,7 +303,7 @@ public class EppoClient extends AndroidBaseClient<JsonNode> {
       }
 
       // Create batteries-included implementations (use provided overrides or defaults)
-      ConfigurationParser<JsonNode> parserToUse =
+      ConfigurationParser<Configuration, Configuration.Builder, JsonNode> parserToUse =
           this.configurationParser != null
               ? this.configurationParser
               : new JacksonConfigurationParser();
@@ -413,12 +413,12 @@ public class EppoClient extends AndroidBaseClient<JsonNode> {
       return instance;
     }
 
-    private CachingConfigurationStore createDefaultConfigStore() {
+    private CachingConfigurationStore<Configuration> createDefaultConfigStore() {
       ConfigurationCodec<Configuration> codec =
-          new ConfigurationCodec.Default<>(Configuration.class);
+          new ConfigurationCodec.Default();
 
       // Cache at a per-API key level (useful for development)
-      return new FileBackedConfigStore(application, safeCacheKey(apiKey), codec);
+      return new FileBackedConfigStore<>(application, safeCacheKey(apiKey), codec);
     }
   }
 

--- a/eppo/src/main/java/cloud/eppo/android/JacksonConfigurationParser.java
+++ b/eppo/src/main/java/cloud/eppo/android/JacksonConfigurationParser.java
@@ -1,6 +1,10 @@
 package cloud.eppo.android;
 
+import androidx.annotation.NonNull;
+
 import cloud.eppo.android.dto.adapters.EppoModule;
+import cloud.eppo.api.Configuration;
+import cloud.eppo.api.SerializableEppoConfiguration;
 import cloud.eppo.api.dto.BanditParametersResponse;
 import cloud.eppo.api.dto.FlagConfigResponse;
 import cloud.eppo.parser.ConfigurationParseException;
@@ -19,7 +23,11 @@ import org.slf4j.LoggerFactory;
  * format. The deserializers are hand-rolled to avoid reliance on annotations and method names,
  * which can be unreliable when ProGuard minification is in use.
  */
-public class JacksonConfigurationParser implements ConfigurationParser<JsonNode> {
+public class JacksonConfigurationParser implements ConfigurationParser<
+  Configuration,
+  Configuration.Builder,
+  JsonNode
+> {
   private static final Logger log = LoggerFactory.getLogger(JacksonConfigurationParser.class);
 
   private final ObjectMapper objectMapper;
@@ -77,5 +85,17 @@ public class JacksonConfigurationParser implements ConfigurationParser<JsonNode>
     } catch (IOException e) {
       throw new ConfigurationParseException("Failed to parse JSON value", e);
     }
+  }
+
+  @NonNull
+  @Override
+  public Configuration.Builder configurationBuilder(@NotNull FlagConfigResponse flagConfigResponse) {
+    return new Configuration.Builder(flagConfigResponse);
+  }
+
+  @NonNull
+  @Override
+  public Configuration.Builder configurationBuilder(@NotNull FlagConfigResponse flagConfigResponse, boolean isConfigObfuscated) {
+    return new Configuration.Builder(flagConfigResponse, isConfigObfuscated);
   }
 }

--- a/example/src/main/java/cloud/eppo/androidexample/CustomClientActivity.java
+++ b/example/src/main/java/cloud/eppo/androidexample/CustomClientActivity.java
@@ -3,6 +3,7 @@ package cloud.eppo.androidexample;
 import static cloud.eppo.androidexample.Constants.INITIAL_FLAG_KEY;
 import static cloud.eppo.androidexample.Constants.INITIAL_SUBJECT_ID;
 
+import android.app.Application;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
@@ -12,15 +13,23 @@ import android.widget.ScrollView;
 import android.widget.TextView;
 import androidx.appcompat.app.AppCompatActivity;
 import cloud.eppo.android.framework.AndroidBaseClient;
+import cloud.eppo.android.framework.storage.CachingConfigurationStore;
 import cloud.eppo.android.framework.storage.FileBackedConfigStore;
 import cloud.eppo.android.framework.util.Utils;
 import cloud.eppo.api.AllocationDetails;
 import cloud.eppo.api.AssignmentDetails;
 import cloud.eppo.api.Attributes;
+import cloud.eppo.api.Configuration;
 import cloud.eppo.api.EvaluationDetails;
+import cloud.eppo.http.EppoConfigurationClient;
+import cloud.eppo.parser.ConfigurationParser;
+
 import com.geteppo.androidexample.BuildConfig;
 import com.geteppo.androidexample.R;
 import com.google.gson.JsonElement;
+
+import org.jetbrains.annotations.NotNull;
+
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.LinkedHashMap;
@@ -48,7 +57,23 @@ public class CustomClientActivity extends AppCompatActivity {
   private TextView assignmentLog;
   private ScrollView assignmentLogScrollView;
 
-  private AndroidBaseClient<JsonElement> client;
+  private AndroidBaseClient<Configuration, Configuration.Builder, JsonElement> client;
+
+  private class GsonAndroidBaseClientBuilder extends AndroidBaseClient.Builder<
+    GsonAndroidBaseClientBuilder,
+    Configuration,
+    Configuration.Builder,
+    JsonElement
+  > {
+    public GsonAndroidBaseClientBuilder(
+      @NotNull String apiKey,
+      @NotNull Application application,
+      @NotNull ConfigurationParser<Configuration, Configuration.Builder, JsonElement> configurationParser,
+      @NotNull CachingConfigurationStore<Configuration> configStore,
+      @NotNull EppoConfigurationClient configurationClient) {
+      super(GsonAndroidBaseClientBuilder.class, apiKey, application, configurationParser, configStore, configurationClient);
+    }
+  }
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -72,18 +97,18 @@ public class CustomClientActivity extends AppCompatActivity {
 
     // Swap in the GSON-based cache codec so the on-disk cache is human-readable JSON
     // rather than Java's binary serialization format.
-    FileBackedConfigStore gsonStore =
-        new FileBackedConfigStore(
+    FileBackedConfigStore<Configuration> gsonStore =
+        new FileBackedConfigStore<>(
             getApplication(), Utils.safeCacheKey(API_KEY), new GsonConfigurationCodec());
 
-    new AndroidBaseClient.Builder<>(
+    new GsonAndroidBaseClientBuilder(
             API_KEY,
             getApplication(),
             new GsonConfigurationParser(),
+            gsonStore,
             new HeaderInjectingEppoClient(customHeaders))
         .forceReinitialize(true)
         .isGracefulMode(false)
-        .configStore(gsonStore)
         .assignmentLogger(
             assignment ->
                 Log.d(

--- a/example/src/main/java/cloud/eppo/androidexample/GsonConfigurationCodec.java
+++ b/example/src/main/java/cloud/eppo/androidexample/GsonConfigurationCodec.java
@@ -1,6 +1,9 @@
 package cloud.eppo.androidexample;
 
 import android.util.Log;
+
+import androidx.annotation.NonNull;
+
 import cloud.eppo.android.framework.storage.ConfigurationCodec;
 import cloud.eppo.api.Configuration;
 import cloud.eppo.api.EppoValue;
@@ -99,6 +102,12 @@ public class GsonConfigurationCodec implements ConfigurationCodec<Configuration>
   @Override
   @NotNull public String getContentType() {
     return "application/json";
+  }
+
+  @NonNull
+  @Override
+  @NotNull public Configuration emptyConfiguration() {
+    return Configuration.emptyConfig();
   }
 
   // ===== Serialization =====

--- a/example/src/main/java/cloud/eppo/androidexample/GsonConfigurationParser.java
+++ b/example/src/main/java/cloud/eppo/androidexample/GsonConfigurationParser.java
@@ -3,7 +3,12 @@ package cloud.eppo.androidexample;
 import static cloud.eppo.Utils.base64Decode;
 
 import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import cloud.eppo.api.Configuration;
 import cloud.eppo.api.EppoValue;
+import cloud.eppo.api.SerializableEppoConfiguration;
 import cloud.eppo.api.dto.Allocation;
 import cloud.eppo.api.dto.BanditCategoricalAttributeCoefficients;
 import cloud.eppo.api.dto.BanditCoefficients;
@@ -29,6 +34,9 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+
+import org.jetbrains.annotations.NotNull;
+
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -57,7 +65,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * to {@code ConfigurationParser<JsonNode>}). It is provided here as a reference implementation and
  * for use with framework clients that are parameterised over {@link JsonElement}.
  */
-public class GsonConfigurationParser implements ConfigurationParser<JsonElement> {
+public class GsonConfigurationParser implements ConfigurationParser<Configuration, Configuration.Builder, JsonElement> {
   private static final String TAG = GsonConfigurationParser.class.getSimpleName();
 
   public GsonConfigurationParser() {}
@@ -104,6 +112,18 @@ public class GsonConfigurationParser implements ConfigurationParser<JsonElement>
     } catch (Exception e) {
       throw new ConfigurationParseException("Failed to parse JSON value", e);
     }
+  }
+
+  @NonNull
+  @Override
+  public Configuration.Builder configurationBuilder(@NotNull FlagConfigResponse flagConfigResponse) {
+    return new Configuration.Builder(flagConfigResponse);
+  }
+
+  @NonNull
+  @Override
+  public Configuration.Builder configurationBuilder(@NotNull FlagConfigResponse flagConfigResponse, boolean isConfigObfuscated) {
+    return new Configuration.Builder(flagConfigResponse, isConfigObfuscated);
   }
 
   // ===== Flag configuration =====


### PR DESCRIPTION
_Eppo Internal:_

[//]: #  (Link to the issue corresponding to this chunk of work)
:tickets: Fixes __issue__
:scroll: Design Doc: __link if applicable__

## Motivation and Context
Needed to update classes dependent on https://github.com/Eppo-exp/sdk-common-jdk/ classes.
Needed to ensure that `AndroidBaseClient` had no `Configuration` dependencies.
See https://github.com/Eppo-exp/sdk-common-jdk/pull/241

## Description
1. Made `AndroidBaseClient` generic over `SerializableEppoConfiguration` and `SerializableEppoConfiguration.AbstractBuilder` types for compatibility with `BaseEppoClient` changes in https://github.com/Eppo-exp/sdk-common-jdk/pull/241
1. `AndroidBaseClient.Builder` generic over `SerializableEppoConfiguration` and `SerializableEppoConfiguration.AbstractBuilder` so that subclasses can reuse it in their builders.
   1. Removed `AndroidBaseClient.Builder.configStore()` because we can't create a `FileBackedConfigStore` for the consumer anymore since `AndroidBaseClient.Builder` is now generic over `SerializableEppoConfiguration`.
1. Checked for required parameters in `AndroidBaseClient.Builder.init`
1. Made `CachingConfigurationStore` and `FiledBackedConfigStore` generic over `SerializableEppoConfiguration` so that they can store any `SerializableEppoConfiguration` and not just `Configuration`.
   1. Added `ConfigurationCodec.emptyConfiguration()` so that `CachingConfigurationStore` to remove a `Configuration` dependency from `CachingConfigurationStore`
1. Removed the type class from `ConfigurationCodec.Default` because `ConfigurationCodec.Default` depends on Jackson for parsing, so only `Configuration` makes sense to use with it.

## How has this been documented?
Added javadoc

## How has this been tested?
Ran unit and Android tests
